### PR TITLE
Database-Backed Column Comparison, Auto-Discovery, and CLI Consolidation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ var/
 .installed.cfg
 *.egg
 .cecli*
+/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.cecli*

--- a/README.md
+++ b/README.md
@@ -203,6 +203,10 @@ The tables.csv file should contain either:
 - A `table_name` column for single table analysis (adds `row_count` and `notes` columns)
 - `source_table` and `target_table` columns for comparison analysis (adds row counts, notes, difference, and percentage difference columns)
 
+**Auto-discovery:** If `tables_file` is omitted from the YAML config, dbqt will
+automatically discover all tables and views in the configured database schema and
+use those for row counts and/or column comparisons.
+
 Table names in the CSV support flexible path formats:
 - `my_table` — uses database/schema from YAML config
 - `my_schema.my_table` — overrides schema, uses database from config

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ dbqt colcompare source.parquet target.parquet
 # Database-backed comparison (fetches metadata from live databases)
 dbqt colcompare --source-config source_config.yaml --target-config target_config.yaml
 
-# Generate a default type mappings configuration file (works with both colcompare and dbstats)
-dbqt colcompare --generate-config
+# Generate a default column type mappings configuration file (works with both colcompare and dbstats)
+dbqt colcompare --generate-col-mappings
 
 # Generate config with custom output path
-dbqt colcompare --generate-config --output my_types.yaml
+dbqt colcompare --generate-col-mappings --output my_types.yaml
 
 # Use custom type mappings for comparison
 dbqt colcompare source.csv target.csv --config my_types.yaml
@@ -131,8 +131,8 @@ dbqt dbstats colcompare --source-config source_config.yaml --target-config targe
 # Both row counts and column comparison in one run
 dbqt dbstats both --source-config source_config.yaml --target-config target_config.yaml
 
-# Generate a default type mappings configuration file
-dbqt dbstats --generate-config
+# Generate a default column type mappings configuration file
+dbqt dbstats --generate-col-mappings
 
 # Also available via aliases
 dbqt rowcount --config config.yaml

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# DBQT (DataBase Quality Tool) 🎯
+# DBQT (DataBase Quality Tool)
 
 DBQT is a lightweight, Python-first data quality testing framework that helps data teams maintain high-quality data through automated checks and intelligent suggestions. 
 
-## 🛠️ Current Tools
+## Current Tools
 
 ### Column Comparison Tool (dbqt colcompare / dbqt compare)
 Compare schemas between databases or files:
@@ -308,7 +308,7 @@ connection:
 - Use `--max-columns` to limit the number of columns analyzed (default: 20)
 - The tool will warn if the combination count exceeds 50,000 (use `--force` to proceed)
 
-## 🚀 Future Plans
+## Future Plans
 
 ### Core DBQT Features (Coming Soon)
 - AI-Powered column classification using Qwen2 0.5B

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ dbqt colcompare --generate-col-mappings --output my_types.yaml
 # Use custom type mappings for comparison
 dbqt colcompare source.csv target.csv --config my_types.yaml
 
+# Exclude specific columns from comparison (CLI flag)
+dbqt colcompare source.csv target.csv --excluded-cols CREATED_AT UPDATED_AT
+
 # Also available via alias
 dbqt compare source.csv target.csv
 ```
@@ -54,9 +57,9 @@ The tool uses intelligent type compatibility checking (e.g., `INT` and `BIGINT` 
    dbqt compare --generate-config
    ```
 
-2. Edit the generated `colcompare_config.yaml` file to add or modify type groups:
+2. Edit the generated `colcompare_config.yaml` file to add or modify type groups and excluded columns:
    ```yaml
-   description: Column comparison type mappings configuration. Each key represents a type group, and the list contains equivalent types.
+   description: Column comparison type mappings configuration. Each key represents a type group, and the list contains equivalent types. excluded_cols is a list of column names to ignore during comparison.
    type_mappings:
      INTEGER:
      - INT
@@ -73,6 +76,10 @@ The tool uses intelligent type compatibility checking (e.g., `INT` and `BIGINT` 
      - NVARCHAR
      - VARCHAR2
      # Add your custom types here
+   # Column names to exclude from comparison (case-insensitive)
+   excluded_cols:
+     - CREATED_AT
+     - UPDATED_AT
    ```
 
 3. Use your custom configuration:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ dbqt colcompare source.parquet target.parquet
 # Database-backed comparison (fetches metadata from live databases)
 dbqt colcompare --source-config source_config.yaml --target-config target_config.yaml
 
-# Generate a default type mappings configuration file
+# Generate a default type mappings configuration file (works with both colcompare and dbstats)
 dbqt colcompare --generate-config
 
 # Generate config with custom output path
@@ -130,6 +130,9 @@ dbqt dbstats colcompare --source-config source_config.yaml --target-config targe
 
 # Both row counts and column comparison in one run
 dbqt dbstats both --source-config source_config.yaml --target-config target_config.yaml
+
+# Generate a default type mappings configuration file
+dbqt dbstats --generate-config
 
 # Also available via aliases
 dbqt rowcount --config config.yaml

--- a/README.md
+++ b/README.md
@@ -205,7 +205,10 @@ The tables.csv file should contain either:
 
 **Auto-discovery:** If `tables_file` is omitted from the YAML config, dbqt will
 automatically discover all tables and views in the configured database schema and
-use those for row counts and/or column comparisons.
+use those for row counts and/or column comparisons. In dual-database mode, only
+tables present in **both** databases will have row counts collected — tables that
+exist in only one side are reported with a note like *"Only in source, row count
+skipped"* since comparing a missing table is not meaningful.
 
 Table names in the CSV support flexible path formats:
 - `my_table` — uses database/schema from YAML config

--- a/README.md
+++ b/README.md
@@ -4,12 +4,15 @@ DBQT is a lightweight, Python-first data quality testing framework that helps da
 
 ## 🛠️ Current Tools
 
-### Column Comparison Tool (dbqt compare)
+### Column Comparison Tool (dbqt colcompare / dbqt compare)
 Compare schemas between databases or files:
 - Table-level comparison
 - Column-level comparison with data type compatibility checks
 - Support for CSV and Parquet files
 - Handles nested Parquet schemas (arrays, structs, maps)
+- **Database-backed comparison** — fetch metadata directly from source/target databases
+- Retrieves precision information (datetime, numeric precision, numeric scale)
+- Supports `table`, `schema.table`, and `db.schema.table` patterns in CSV files
 - Intelligent data type compatibility checking
 - **Customizable type mappings via YAML configuration**
 - Generates detailed Excel report with:
@@ -20,20 +23,26 @@ Compare schemas between databases or files:
 
 Usage:
 ```bash
-# Basic comparison
-dbqt compare source_schema.csv target_schema.csv
+# Basic file-based comparison
+dbqt colcompare source_schema.csv target_schema.csv
 
 # Compare Parquet files directly
-dbqt compare source.parquet target.parquet
+dbqt colcompare source.parquet target.parquet
+
+# Database-backed comparison (fetches metadata from live databases)
+dbqt colcompare --source-config source_config.yaml --target-config target_config.yaml
 
 # Generate a default type mappings configuration file
-dbqt compare --generate-config
+dbqt colcompare --generate-config
 
 # Generate config with custom output path
-dbqt compare --generate-config --output my_types.yaml
+dbqt colcompare --generate-config --output my_types.yaml
 
 # Use custom type mappings for comparison
-dbqt compare source.csv target.csv --config my_types.yaml
+dbqt colcompare source.csv target.csv --config my_types.yaml
+
+# Also available via alias
+dbqt compare source.csv target.csv
 ```
 
 **Customizing Type Mappings:**
@@ -96,22 +105,35 @@ Usage:
 dbqt combine [output.parquet]  # Combines all .parquet files in current directory
 ```
 
-### Database Statistics Tool (dbqt dbstats)
-Collect and analyze database statistics:
-- Fetches table row counts in parallel for faster execution
+### Database Statistics Tool (dbqt dbstats / dbqt rowcount / dbqt stats)
+Collect and analyze database statistics with multiple modes:
+- **rowcount** (default) — Fetches table row counts in parallel
+- **colcompare** — Compares column schemas between source and target databases
+- **both** — Runs row counts then column comparison in one command
 - Supports both single table analysis and source/target table comparisons
-- **NEW: Supports separate source and target database configurations** for cross-database comparisons
+- Supports separate source and target database configurations for cross-database comparisons
+- Supports `table`, `schema.table`, and `db.schema.table` patterns in CSV files
 - Automatically calculates differences and percentage changes for comparisons
 - Updates statistics in a CSV file with comprehensive error reporting
 - Configurable through YAML
 
 Usage:
 ```bash
-# Single database mode (source and target in same database)
+# Row counts — single database mode
 dbqt dbstats --config config.yaml
 
-# Dual database mode (source and target in different databases)
+# Row counts — dual database mode (source and target in different databases)
 dbqt dbstats --source-config source_config.yaml --target-config target_config.yaml
+
+# Column comparison via dbstats
+dbqt dbstats colcompare --source-config source_config.yaml --target-config target_config.yaml
+
+# Both row counts and column comparison in one run
+dbqt dbstats both --source-config source_config.yaml --target-config target_config.yaml
+
+# Also available via aliases
+dbqt rowcount --config config.yaml
+dbqt stats --config config.yaml
 ```
 
 Example config.yaml (single database mode):
@@ -177,6 +199,11 @@ connection:
 The tables.csv file should contain either:
 - A `table_name` column for single table analysis (adds `row_count` and `notes` columns)
 - `source_table` and `target_table` columns for comparison analysis (adds row counts, notes, difference, and percentage difference columns)
+
+Table names in the CSV support flexible path formats:
+- `my_table` — uses database/schema from YAML config
+- `my_schema.my_table` — overrides schema, uses database from config
+- `my_db.my_schema.my_table` — fully qualified, ignores config defaults
 
 **Note:** When using dual database mode (`--source-config` and `--target-config`), the tool will:
 - Connect to the source database to count rows in `source_table` column

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The tool uses intelligent type compatibility checking (e.g., `INT` and `BIGINT` 
 
 1. Generate a default configuration file:
    ```bash
-   dbqt compare --generate-config
+   dbqt compare --generate-col-mappings
    ```
 
 2. Edit the generated `colcompare_config.yaml` file to add or modify type groups and excluded columns:

--- a/dbqt/app.py
+++ b/dbqt/app.py
@@ -120,7 +120,9 @@ def main():
         print(f"Error importing tool '{tool_name}': {e}")
         sys.exit(1)
     except Exception as e:
+        import traceback
         print(f"Error running tool '{tool_name}': {e}")
+        traceback.print_exc()
         sys.exit(1)
 
 

--- a/dbqt/connections.py
+++ b/dbqt/connections.py
@@ -14,7 +14,7 @@ from reladiff import connect as reladiff_connect
 logger = logging.getLogger(__name__)
 
 
-def _normalize_table_path(table_name, config=None):
+def normalize_table_path(table_name, config=None):
     """Resolve table_name into (database, schema, table) using config defaults."""
     if config is None:
         config = {}
@@ -29,7 +29,7 @@ def _normalize_table_path(table_name, config=None):
         return default_db, default_schema, parts[0]
 
 
-def _qualified_name(database, schema, table_name):
+def build_qualified_table_name(database, schema, table_name):
     """Build a dot-separated qualified name, skipping None components."""
     return ".".join(p for p in (database, schema, table_name) if p)
 
@@ -63,7 +63,7 @@ class DBConnector(ABC):
         return result
 
     def fetch_table_metadata(self, table_name):
-        db, schema, tbl = _normalize_table_path(table_name, self.config)
+        db, schema, tbl = normalize_table_path(table_name, self.config)
         where_parts = [f"upper(table_name) = upper('{tbl}')"]
         if schema:
             where_parts.append(f"upper(table_schema) = upper('{schema}')")
@@ -92,8 +92,8 @@ class DBConnector(ABC):
     def count_rows(self, table_name, where_clause=None):
         """Retrieve the total number of rows in a table."""
         try:
-            db, schema, tbl = _normalize_table_path(table_name, self.config)
-            qualified = _qualified_name(db, schema, tbl)
+            db, schema, tbl = normalize_table_path(table_name, self.config)
+            qualified = build_qualified_table_name(db, schema, tbl)
             query = f"SELECT COUNT(*) FROM {qualified}"
             if where_clause:
                 query += f" WHERE {where_clause}"
@@ -117,7 +117,7 @@ class MySQL(DBConnector):
         return conn_str
 
     def fetch_table_metadata(self, table_name):
-        db, schema, tbl = _normalize_table_path(table_name, self.config)
+        db, schema, tbl = normalize_table_path(table_name, self.config)
         db_filter = schema or self.config.get("database", "")
         query = f"""
         SELECT UPPER(COLUMN_NAME) AS COLUMN_NAME, DATA_TYPE,
@@ -144,7 +144,7 @@ class Snowflake(DBConnector):
         return conn_str
 
     def fetch_table_metadata(self, table_name):
-        db, schema, tbl = _normalize_table_path(table_name, self.config)
+        db, schema, tbl = normalize_table_path(table_name, self.config)
         catalog = db or self.config.get("database", "")
         schema = schema or self.config.get("schema", "")
         query = f"""
@@ -330,7 +330,7 @@ class SQLServer(DBConnector):
         return result if result else "Success"
 
     def fetch_table_metadata(self, table_name):
-        db, schema, tbl = _normalize_table_path(table_name, self.config)
+        db, schema, tbl = normalize_table_path(table_name, self.config)
         schema = schema or self.config.get("schema", "dbo")
         query = f"""
         SELECT UPPER(COLUMN_NAME) AS COLUMN_NAME, DATA_TYPE,
@@ -436,7 +436,7 @@ class Oracle(DBConnector):
         return result if result else "Success"
 
     def fetch_table_metadata(self, table_name):
-        db, schema, tbl = _normalize_table_path(table_name, self.config)
+        db, schema, tbl = normalize_table_path(table_name, self.config)
         schema = schema or self.config.get("schema", self.config["user"].upper())
         query = f"""
         SELECT UPPER(COLUMN_NAME) AS COLUMN_NAME, DATA_TYPE,

--- a/dbqt/connections.py
+++ b/dbqt/connections.py
@@ -103,6 +103,27 @@ class DBConnector(ABC):
             self.logger.error(f"Error counting rows for {table_name}: {str(e)}")
             return None
 
+    def fetch_schema_metadata(self, schema=None):
+        """Fetch column metadata for ALL tables in a schema in one query.
+
+        Returns a list of (table_name, column_name, data_type,
+        datetime_precision, numeric_precision, numeric_scale) tuples.
+        """
+        schema = schema or self.config.get("schema")
+        where_parts = []
+        if schema:
+            where_parts.append(f"upper(table_schema) = upper('{schema}')")
+        where_clause = f" WHERE {' AND '.join(where_parts)}" if where_parts else ""
+        query = (
+            "SELECT table_name, column_name, data_type,"
+            " datetime_precision, numeric_precision, numeric_scale"
+            f" FROM information_schema.columns{where_clause}"
+            " ORDER BY table_name, ordinal_position"
+        )
+        self.logger.info(f"Fetching schema-wide metadata (schema={schema})")
+        result = self.run_query(query)
+        return [(row[0], row[1], row[2], row[3], row[4], row[5]) for row in result]
+
     def list_tables(self, schema=None):
         """List all tables and views in the given schema (or config default)."""
         schema = schema or self.config.get("schema")
@@ -129,6 +150,19 @@ class DBConnector(ABC):
 
 
 class MySQL(DBConnector):
+    def fetch_schema_metadata(self, schema=None):
+        schema = schema or self.config.get("database", "")
+        query = f"""
+        SELECT UPPER(TABLE_NAME), UPPER(COLUMN_NAME), DATA_TYPE,
+               DATETIME_PRECISION, NUMERIC_PRECISION, NUMERIC_SCALE
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE UPPER(TABLE_SCHEMA) = UPPER('{schema}')
+        ORDER BY TABLE_NAME, ORDINAL_POSITION
+        """
+        self.logger.info(f"Fetching schema-wide metadata (database={schema})")
+        result = self.run_query(query)
+        return [(row[0], row[1], row[2], row[3], row[4], row[5]) for row in result]
+
     def list_tables(self, schema=None):
         schema = schema or self.config.get("database")
         if not schema:
@@ -166,6 +200,21 @@ class MySQL(DBConnector):
 
 
 class Snowflake(DBConnector):
+    def fetch_schema_metadata(self, schema=None):
+        catalog = self.config.get("database", "")
+        schema = schema or self.config.get("schema", "")
+        query = f"""
+        SELECT UPPER(TABLE_NAME), UPPER(COLUMN_NAME), DATA_TYPE,
+               DATETIME_PRECISION, NUMERIC_PRECISION, NUMERIC_SCALE
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE UPPER(TABLE_CATALOG) = UPPER('{catalog}')
+        AND UPPER(TABLE_SCHEMA) = UPPER('{schema}')
+        ORDER BY TABLE_NAME, ORDINAL_POSITION
+        """
+        self.logger.info(f"Fetching schema-wide metadata ({catalog}.{schema})")
+        result = self.run_query(query)
+        return [(row[0], row[1], row[2], row[3], row[4], row[5]) for row in result]
+
     def list_tables(self, schema=None):
         catalog = self.config.get("database", "")
         schema = schema or self.config.get("schema", "")
@@ -349,6 +398,19 @@ class PostgreSQL(DBConnector):
 
 
 class SQLServer(DBConnector):
+    def fetch_schema_metadata(self, schema=None):
+        schema = schema or self.config.get("schema", "dbo")
+        query = f"""
+        SELECT UPPER(TABLE_NAME), UPPER(COLUMN_NAME), DATA_TYPE,
+               DATETIME_PRECISION, NUMERIC_PRECISION, NUMERIC_SCALE
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE UPPER(TABLE_SCHEMA) = UPPER('{schema}')
+        ORDER BY TABLE_NAME, ORDINAL_POSITION
+        """
+        self.logger.info(f"Fetching schema-wide metadata (schema={schema})")
+        result = self.run_query(query)
+        return [(row[0], row[1], row[2], row[3], row[4], row[5]) for row in result]
+
     def list_tables(self, schema=None):
         schema = schema or self.config.get("schema", "dbo")
         query = (
@@ -407,6 +469,20 @@ class SQLServer(DBConnector):
 
 
 class Oracle(DBConnector):
+    def fetch_schema_metadata(self, schema=None):
+        schema = schema or self.config.get("schema", self.config["user"].upper())
+        query = f"""
+        SELECT UPPER(TABLE_NAME), UPPER(COLUMN_NAME), DATA_TYPE,
+               6 AS DATETIME_PRECISION, DATA_PRECISION AS NUMERIC_PRECISION,
+               DATA_SCALE AS NUMERIC_SCALE
+        FROM ALL_TAB_COLUMNS
+        WHERE UPPER(OWNER) = UPPER('{schema}')
+        ORDER BY TABLE_NAME, COLUMN_ID
+        """
+        self.logger.info(f"Fetching schema-wide metadata (schema={schema})")
+        result = self.run_query(query)
+        return [(row[0], row[1], row[2], row[3], row[4], row[5]) for row in result]
+
     def list_tables(self, schema=None):
         schema = schema or self.config.get("schema", self.config["user"].upper())
         query = (

--- a/dbqt/connections.py
+++ b/dbqt/connections.py
@@ -103,6 +103,24 @@ class DBConnector(ABC):
             self.logger.error(f"Error counting rows for {table_name}: {str(e)}")
             return None
 
+    def list_tables(self, schema=None):
+        """List all tables and views in the given schema (or config default)."""
+        schema = schema or self.config.get("schema")
+        if not schema:
+            raise ValueError(
+                "Cannot discover tables: no schema specified in config or argument"
+            )
+        query = (
+            "SELECT table_name FROM information_schema.tables"
+            f" WHERE upper(table_schema) = upper('{schema}')"
+            " ORDER BY table_name"
+        )
+        self.logger.info(f"Discovering tables in schema: {schema}")
+        result = self.run_query(query)
+        tables = [row[0] for row in result]
+        self.logger.info(f"Found {len(tables)} tables in schema {schema}")
+        return tables
+
     def generate_table_from_query(self, table_name, query):
         self.logger.info(f"Generating table {table_name}")
         self.run_query(f"DROP TABLE IF EXISTS {table_name}")
@@ -111,6 +129,21 @@ class DBConnector(ABC):
 
 
 class MySQL(DBConnector):
+    def list_tables(self, schema=None):
+        schema = schema or self.config.get("database")
+        if not schema:
+            raise ValueError("Cannot discover tables: no database specified in config")
+        query = (
+            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES"
+            f" WHERE UPPER(TABLE_SCHEMA) = UPPER('{schema}')"
+            " ORDER BY TABLE_NAME"
+        )
+        self.logger.info(f"Discovering tables in database: {schema}")
+        result = self.run_query(query)
+        tables = [row[0] for row in result]
+        self.logger.info(f"Found {len(tables)} tables in database {schema}")
+        return tables
+
     @property
     def connection_details(self):
         conn_str = f"mysql://{self.config['user']}:{self.config['password']}@{self.config['host']}:{self.config.get('port', '3306')}/{self.config.get('database', 'information_schema')}"
@@ -133,6 +166,21 @@ class MySQL(DBConnector):
 
 
 class Snowflake(DBConnector):
+    def list_tables(self, schema=None):
+        catalog = self.config.get("database", "")
+        schema = schema or self.config.get("schema", "")
+        query = (
+            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES"
+            f" WHERE UPPER(TABLE_CATALOG) = UPPER('{catalog}')"
+            f" AND UPPER(TABLE_SCHEMA) = UPPER('{schema}')"
+            " ORDER BY TABLE_NAME"
+        )
+        self.logger.info(f"Discovering tables in {catalog}.{schema}")
+        result = self.run_query(query)
+        tables = [row[0] for row in result]
+        self.logger.info(f"Found {len(tables)} tables in {catalog}.{schema}")
+        return tables
+
     @property
     def connection_details(self):
         auth = (
@@ -301,6 +349,19 @@ class PostgreSQL(DBConnector):
 
 
 class SQLServer(DBConnector):
+    def list_tables(self, schema=None):
+        schema = schema or self.config.get("schema", "dbo")
+        query = (
+            "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES"
+            f" WHERE UPPER(TABLE_SCHEMA) = UPPER('{schema}')"
+            " ORDER BY TABLE_NAME"
+        )
+        self.logger.info(f"Discovering tables in schema: {schema}")
+        result = self.run_query(query)
+        tables = [row[0] for row in result]
+        self.logger.info(f"Found {len(tables)} tables in schema {schema}")
+        return tables
+
     @property
     def connection_details(self):
         # Build connection string for SQL Server / Azure Synapse
@@ -346,6 +407,22 @@ class SQLServer(DBConnector):
 
 
 class Oracle(DBConnector):
+    def list_tables(self, schema=None):
+        schema = schema or self.config.get("schema", self.config["user"].upper())
+        query = (
+            "SELECT TABLE_NAME FROM ALL_TABLES"
+            f" WHERE UPPER(OWNER) = UPPER('{schema}')"
+            " UNION"
+            " SELECT VIEW_NAME AS TABLE_NAME FROM ALL_VIEWS"
+            f" WHERE UPPER(OWNER) = UPPER('{schema}')"
+            " ORDER BY TABLE_NAME"
+        )
+        self.logger.info(f"Discovering tables in schema: {schema}")
+        result = self.run_query(query)
+        tables = [row[0] for row in result]
+        self.logger.info(f"Found {len(tables)} tables in schema {schema}")
+        return tables
+
     def __init__(self, config):
         super().__init__(config)
         self.jdbc_driver = config.get("jdbc_driver", "oracle.jdbc.OracleDriver")
@@ -453,6 +530,18 @@ class Oracle(DBConnector):
 
 
 class Athena(DBConnector):
+    def list_tables(self, schema=None):
+        database = schema or self.config.get("database")
+        if not database:
+            raise ValueError("Cannot discover tables: no database specified in config")
+        query = f"SHOW TABLES IN {database}"
+        self.logger.info(f"Discovering tables in database: {database}")
+        result = self.run_query(query)
+        # Athena SHOW TABLES returns rows with header; skip first row
+        tables = [row[0] for row in result[1:] if row[0]]
+        self.logger.info(f"Found {len(tables)} tables in database {database}")
+        return tables
+
     def __init__(self, config):
         super().__init__(config)
         self.session = boto3.Session(profile_name=config.get("aws_profile", "default"))

--- a/dbqt/connections.py
+++ b/dbqt/connections.py
@@ -14,6 +14,26 @@ from reladiff import connect as reladiff_connect
 logger = logging.getLogger(__name__)
 
 
+def _normalize_table_path(table_name, config=None):
+    """Resolve table_name into (database, schema, table) using config defaults."""
+    if config is None:
+        config = {}
+    parts = table_name.split(".")
+    default_db = config.get("database") or config.get("sid")
+    default_schema = config.get("schema")
+    if len(parts) == 3:
+        return parts[0], parts[1], parts[2]
+    elif len(parts) == 2:
+        return default_db, parts[0], parts[1]
+    else:
+        return default_db, default_schema, parts[0]
+
+
+def _qualified_name(database, schema, table_name):
+    """Build a dot-separated qualified name, skipping None components."""
+    return ".".join(p for p in (database, schema, table_name) if p)
+
+
 class DBConnector(ABC):
     def __init__(self, config):
         self.config = config
@@ -43,15 +63,19 @@ class DBConnector(ABC):
         return result
 
     def fetch_table_metadata(self, table_name):
-        query = f"""
-        SELECT column_name, data_type
-        FROM information_schema.columns
-        WHERE upper(table_name) = upper('{table_name}')
-        ORDER BY ordinal_position
-        """
+        db, schema, tbl = _normalize_table_path(table_name, self.config)
+        where_parts = [f"upper(table_name) = upper('{tbl}')"]
+        if schema:
+            where_parts.append(f"upper(table_schema) = upper('{schema}')")
+        query = (
+            "SELECT column_name, data_type, datetime_precision, numeric_precision, numeric_scale"
+            " FROM information_schema.columns"
+            f" WHERE {' AND '.join(where_parts)}"
+            " ORDER BY ordinal_position"
+        )
         self.logger.info(f"Fetching metadata for table: {table_name}")
         result = self.run_query(query)
-        return [(row[0], row[1]) for row in result]
+        return [(row[0], row[1], row[2], row[3], row[4]) for row in result]
 
     def retrieve_table(self, table_name):
         return table(table_name)
@@ -62,12 +86,15 @@ class DBConnector(ABC):
                 col[0].upper(): col[1] for col in self.fetch_table_metadata(table_name)
             }
         except Exception as e:
-            print(f"Error retrieving source table metadata: {str(e)}")
+            self.logger.error(f"Error retrieving source table metadata: {str(e)}")
+            return {}
 
     def count_rows(self, table_name, where_clause=None):
         """Retrieve the total number of rows in a table."""
         try:
-            query = f"SELECT COUNT(*) FROM {table_name}"
+            db, schema, tbl = _normalize_table_path(table_name, self.config)
+            qualified = _qualified_name(db, schema, tbl)
+            query = f"SELECT COUNT(*) FROM {qualified}"
             if where_clause:
                 query += f" WHERE {where_clause}"
             result = self.run_query(query)
@@ -90,16 +117,19 @@ class MySQL(DBConnector):
         return conn_str
 
     def fetch_table_metadata(self, table_name):
+        db, schema, tbl = _normalize_table_path(table_name, self.config)
+        db_filter = schema or self.config.get("database", "")
         query = f"""
-        SELECT UPPER(COLUMN_NAME) AS COLUMN_NAME, DATA_TYPE
+        SELECT UPPER(COLUMN_NAME) AS COLUMN_NAME, DATA_TYPE,
+               DATETIME_PRECISION, NUMERIC_PRECISION, NUMERIC_SCALE
         FROM INFORMATION_SCHEMA.COLUMNS
-        WHERE UPPER(TABLE_SCHEMA) = UPPER('{self.config['database']}') 
-        AND UPPER(TABLE_NAME) = UPPER('{table_name}')
+        WHERE UPPER(TABLE_SCHEMA) = UPPER('{db_filter}') 
+        AND UPPER(TABLE_NAME) = UPPER('{tbl}')
         ORDER BY ORDINAL_POSITION
         """
         self.logger.info(f"Fetching metadata for table: {table_name}")
         result = self.run_query(query)
-        return [(row[0], row[1]) for row in result]
+        return [(row[0], row[1], row[2], row[3], row[4]) for row in result]
 
 
 class Snowflake(DBConnector):
@@ -114,18 +144,22 @@ class Snowflake(DBConnector):
         return conn_str
 
     def fetch_table_metadata(self, table_name):
+        db, schema, tbl = _normalize_table_path(table_name, self.config)
+        catalog = db or self.config.get("database", "")
+        schema = schema or self.config.get("schema", "")
         query = f"""
-        SELECT UPPER(COLUMN_NAME) AS COLUMN_NAME, DATA_TYPE
+        SELECT UPPER(COLUMN_NAME) AS COLUMN_NAME, DATA_TYPE,
+               DATETIME_PRECISION, NUMERIC_PRECISION, NUMERIC_SCALE
         FROM INFORMATION_SCHEMA.COLUMNS
         WHERE 
-        UPPER(TABLE_CATALOG) = UPPER('{self.config['database']}') 
-        AND UPPER(TABLE_SCHEMA) = UPPER('{self.config['schema']}') 
-        AND UPPER(TABLE_NAME) = UPPER('{table_name}')
+        UPPER(TABLE_CATALOG) = UPPER('{catalog}') 
+        AND UPPER(TABLE_SCHEMA) = UPPER('{schema}') 
+        AND UPPER(TABLE_NAME) = UPPER('{tbl}')
         ORDER BY ORDINAL_POSITION
         """
         self.logger.info(f"Fetching metadata for table: {table_name}")
         result = self.run_query(query)
-        return [(row[0], row[1]) for row in result]
+        return [(row[0], row[1], row[2], row[3], row[4]) for row in result]
 
 
 class DuckDB(DBConnector):
@@ -296,23 +330,19 @@ class SQLServer(DBConnector):
         return result if result else "Success"
 
     def fetch_table_metadata(self, table_name):
-        # Handle schema.table format
-        if "." in table_name:
-            schema, table = table_name.split(".", 1)
-        else:
-            schema = self.config.get("schema", "dbo")
-            table = table_name
-
+        db, schema, tbl = _normalize_table_path(table_name, self.config)
+        schema = schema or self.config.get("schema", "dbo")
         query = f"""
-        SELECT UPPER(COLUMN_NAME) AS COLUMN_NAME, DATA_TYPE
+        SELECT UPPER(COLUMN_NAME) AS COLUMN_NAME, DATA_TYPE,
+               DATETIME_PRECISION, NUMERIC_PRECISION, NUMERIC_SCALE
         FROM INFORMATION_SCHEMA.COLUMNS
         WHERE UPPER(TABLE_SCHEMA) = UPPER('{schema}') 
-        AND UPPER(TABLE_NAME) = UPPER('{table}')
+        AND UPPER(TABLE_NAME) = UPPER('{tbl}')
         ORDER BY ORDINAL_POSITION
         """
-        self.logger.info(f"Fetching metadata for table: {schema}.{table}")
+        self.logger.info(f"Fetching metadata for table: {schema}.{tbl}")
         result = self.run_query(query)
-        return [(row[0], row[1]) for row in result]
+        return [(row[0], row[1], row[2], row[3], row[4]) for row in result]
 
 
 class Oracle(DBConnector):
@@ -406,23 +436,20 @@ class Oracle(DBConnector):
         return result if result else "Success"
 
     def fetch_table_metadata(self, table_name):
-        # Handle schema.table format
-        if "." in table_name:
-            schema, table = table_name.split(".", 1)
-        else:
-            schema = self.config.get("schema", self.config["user"].upper())
-            table = table_name
-
+        db, schema, tbl = _normalize_table_path(table_name, self.config)
+        schema = schema or self.config.get("schema", self.config["user"].upper())
         query = f"""
-        SELECT UPPER(COLUMN_NAME) AS COLUMN_NAME, DATA_TYPE
+        SELECT UPPER(COLUMN_NAME) AS COLUMN_NAME, DATA_TYPE,
+               6 AS DATETIME_PRECISION, DATA_PRECISION AS NUMERIC_PRECISION,
+               DATA_SCALE AS NUMERIC_SCALE
         FROM ALL_TAB_COLUMNS
         WHERE UPPER(OWNER) = UPPER('{schema}') 
-        AND UPPER(TABLE_NAME) = UPPER('{table}')
+        AND UPPER(TABLE_NAME) = UPPER('{tbl}')
         ORDER BY COLUMN_ID
         """
-        self.logger.info(f"Fetching metadata for table: {schema}.{table}")
+        self.logger.info(f"Fetching metadata for table: {schema}.{tbl}")
         result = self.run_query(query)
-        return [(row[0], row[1]) for row in result]
+        return [(row[0], row[1], row[2], row[3], row[4]) for row in result]
 
 
 class Athena(DBConnector):

--- a/dbqt/tools/__init__.py
+++ b/dbqt/tools/__init__.py
@@ -6,5 +6,6 @@ Maps command aliases to their actual tool module names.
 TOOL_ALIASES = {
     "compare": "colcompare",
     "rowcount": "dbstats",
+    "stats": "dbstats",
     "findkey": "keyfinder",
 }

--- a/dbqt/tools/colcompare.py
+++ b/dbqt/tools/colcompare.py
@@ -410,6 +410,8 @@ To generate a default configuration file:
         setup_logging(args.verbose)
 
         if args.generate_config:
+            from dbqt.tools.colcompare import generate_config_file
+
             generate_config_file(args.output)
             return
 

--- a/dbqt/tools/colcompare.py
+++ b/dbqt/tools/colcompare.py
@@ -1,21 +1,29 @@
+"""Column comparison tool — compare schemas between files or databases."""
+
 import argparse
-import polars as pl
 import re
+import os
+import logging
+from datetime import datetime
+from pathlib import Path
+
+import polars as pl
 import pyarrow
 import pyarrow.parquet as pq
+import yaml
 from openpyxl import Workbook
 from openpyxl.styles import PatternFill, Font, Alignment
 from openpyxl.utils import get_column_letter
-import os
-from datetime import datetime
-from pathlib import Path
-import yaml
-from dbqt.tools.utils import Timer, setup_logging
-import logging
+
+from dbqt.tools.utils import load_config, setup_logging, Timer
+from dbqt.tools.dbstats import fetch_metadata_parallel, _read_table_lists
 
 logger = logging.getLogger(__name__)
 
-# Define default type mappings for equivalent data types
+# ---------------------------------------------------------------------------
+# Type-mapping helpers
+# ---------------------------------------------------------------------------
+
 DEFAULT_TYPE_MAPPINGS = {
     "INTEGER": ["INT", "INTEGER", "BIGINT", "SMALLINT", "TINYINT", "NUMBER"],
     "VARCHAR": ["VARCHAR", "TEXT", "CHAR", "STRING", "NVARCHAR", "VARCHAR2"],
@@ -28,7 +36,7 @@ DEFAULT_TYPE_MAPPINGS = {
 
 
 def load_type_mappings(config_path=None):
-    """Load type mappings from YAML config file or return defaults"""
+    """Load type mappings from YAML config file or return defaults."""
     if config_path and Path(config_path).exists():
         logger.info(f"Loading type mappings from {config_path}")
         with open(config_path, "r") as f:
@@ -38,7 +46,7 @@ def load_type_mappings(config_path=None):
 
 
 def generate_config_file(output_path="colcompare_config.yaml"):
-    """Generate a default configuration file with type mappings"""
+    """Generate a default configuration file with type mappings."""
     config = {
         "type_mappings": DEFAULT_TYPE_MAPPINGS,
         "description": "Column comparison type mappings configuration. "
@@ -62,25 +70,20 @@ def generate_config_file(output_path="colcompare_config.yaml"):
 
 
 def are_types_compatible(type1, type2, type_mappings=None):
-    """Check if two data types are considered compatible"""
+    """Check if two data types are considered compatible."""
     if type_mappings is None:
         type_mappings = DEFAULT_TYPE_MAPPINGS
 
     type1, type2 = type1.upper(), type2.upper()
-
-    # Strip length specifications like VARCHAR(50) to VARCHAR
     type1 = type1.split("(")[0].strip()
     type2 = type2.split("(")[0].strip()
 
-    # If types are exactly the same, they're compatible
     if type1 == type2:
         return True
 
-    # Special handling for TIMESTAMP variations
     if re.match(r"^TIMESTAMP.*", type1) and re.match(r"^TIMESTAMP.*", type2):
         return True
 
-    # Check if types belong to the same group
     for type_group in type_mappings.values():
         if type1 in type_group and type2 in type_group:
             return True
@@ -88,20 +91,22 @@ def are_types_compatible(type1, type2, type_mappings=None):
     return False
 
 
+# ---------------------------------------------------------------------------
+# Parquet / file-based schema helpers
+# ---------------------------------------------------------------------------
+
+
 def _process_nested_type(field_type, parent_name="", processed_fields=None):
-    """Recursively process nested types in Parquet schema"""
+    """Recursively process nested types in Parquet schema."""
     if processed_fields is None:
         processed_fields = []
 
-    # Handle list types
     if isinstance(field_type, (pyarrow.lib.ListType, pyarrow.lib.LargeListType)):
         element_type = field_type.value_type
         if isinstance(element_type, pyarrow.lib.StructType):
             for nested_field in element_type:
                 full_name = (
-                    f"{parent_name}__{nested_field.name}"
-                    if parent_name
-                    else nested_field.name
+                    f"{parent_name}__{nested_field.name}" if parent_name else nested_field.name
                 )
                 if isinstance(
                     nested_field.type,
@@ -114,19 +119,14 @@ def _process_nested_type(field_type, parent_name="", processed_fields=None):
                 ):
                     _process_nested_type(nested_field.type, full_name, processed_fields)
                 else:
-                    processed_fields.append(
-                        {"col_name": full_name, "type": str(nested_field.type)}
-                    )
+                    processed_fields.append({"col_name": full_name, "type": str(nested_field.type)})
         else:
             processed_fields.append({"col_name": parent_name, "type": str(field_type)})
 
-    # Handle struct types
     elif isinstance(field_type, pyarrow.lib.StructType):
         for nested_field in field_type:
             full_name = (
-                f"{parent_name}__{nested_field.name}"
-                if parent_name
-                else nested_field.name
+                f"{parent_name}__{nested_field.name}" if parent_name else nested_field.name
             )
             if isinstance(
                 nested_field.type,
@@ -139,286 +139,244 @@ def _process_nested_type(field_type, parent_name="", processed_fields=None):
             ):
                 _process_nested_type(nested_field.type, full_name, processed_fields)
             else:
-                processed_fields.append(
-                    {"col_name": full_name, "type": str(nested_field.type)}
-                )
+                processed_fields.append({"col_name": full_name, "type": str(nested_field.type)})
 
-    # Handle map types
     elif isinstance(field_type, pyarrow.lib.MapType):
         processed_fields.append({"col_name": parent_name, "type": str(field_type)})
 
     return processed_fields
 
 
+def _schema_to_df(schema, label="pq"):
+    """Convert a pyarrow schema to a Polars DataFrame with SCH_TABLE/COL_NAME/DATA_TYPE."""
+    fields = []
+    for field in schema:
+        if isinstance(
+            field.type,
+            (
+                pyarrow.lib.ListType,
+                pyarrow.lib.LargeListType,
+                pyarrow.lib.StructType,
+                pyarrow.lib.MapType,
+            ),
+        ):
+            fields.extend(_process_nested_type(field.type, field.name))
+        else:
+            fields.append({"col_name": field.name, "type": str(field.type)})
+
+    return pl.DataFrame(
+        {
+            "SCH_TABLE": [label] * len(fields),
+            "COL_NAME": [f["col_name"] for f in fields],
+            "DATA_TYPE": [f["type"] for f in fields],
+        }
+    )
+
+
 def compare_and_unnest_parquet_schema(source_path, target_path):
-    """Compare schemas of two Parquet files without loading full dataset"""
-    schema1 = pq.read_schema(source_path)
-    schema2 = pq.read_schema(target_path)
-
-    # Process both schemas to expand nested fields
-    processed_fields1 = []
-    processed_fields2 = []
-
-    for field in schema1:
-        if isinstance(
-            field.type,
-            (
-                pyarrow.lib.ListType,
-                pyarrow.lib.LargeListType,
-                pyarrow.lib.StructType,
-                pyarrow.lib.MapType,
-            ),
-        ):
-            processed_fields1.extend(_process_nested_type(field.type, field.name))
-        else:
-            processed_fields1.append({"col_name": field.name, "type": str(field.type)})
-
-    for field in schema2:
-        if isinstance(
-            field.type,
-            (
-                pyarrow.lib.ListType,
-                pyarrow.lib.LargeListType,
-                pyarrow.lib.StructType,
-                pyarrow.lib.MapType,
-            ),
-        ):
-            processed_fields2.extend(_process_nested_type(field.type, field.name))
-        else:
-            processed_fields2.append({"col_name": field.name, "type": str(field.type)})
-
-    # Convert processed fields to polars DataFrame
-    schema1_df = pl.DataFrame(
-        {
-            "SCH_TABLE": ["pq"] * len(processed_fields1),
-            "COL_NAME": [f["col_name"] for f in processed_fields1],
-            "DATA_TYPE": [f["type"] for f in processed_fields1],
-        }
+    """Compare schemas of two Parquet files without loading full dataset."""
+    return (
+        _schema_to_df(pq.read_schema(source_path)),
+        _schema_to_df(pq.read_schema(target_path)),
     )
-
-    schema2_df = pl.DataFrame(
-        {
-            "SCH_TABLE": ["pq"] * len(processed_fields2),
-            "COL_NAME": [f["col_name"] for f in processed_fields2],
-            "DATA_TYPE": [f["type"] for f in processed_fields2],
-        }
-    )
-
-    return schema1_df, schema2_df
 
 
 def read_files(source_path, target_path):
-    """Read source and target files using Polars"""
-    # Check if files are Parquet
+    """Read source and target files using Polars."""
     if source_path.endswith(".parquet") and target_path.endswith(".parquet"):
-        # For Parquet files, only load the schema information
-        source_df, target_df = compare_and_unnest_parquet_schema(
-            source_path, target_path
-        )
-    else:
-        source_df = pl.read_csv(source_path)
-        target_df = pl.read_csv(target_path)
+        return compare_and_unnest_parquet_schema(source_path, target_path)
 
-        # Handle missing DATA_TYPE column
-        if "DATA_TYPE" not in source_df.columns:
-            source_df = source_df.with_columns(pl.lit("N/A").alias("DATA_TYPE"))
-        if "DATA_TYPE" not in target_df.columns:
-            target_df = target_df.with_columns(pl.lit("N/A").alias("DATA_TYPE"))
+    source_df = pl.read_csv(source_path)
+    target_df = pl.read_csv(target_path)
 
-        # Create SCH_TABLE column - concatenate SCH and NAME if SCH exists, otherwise use NAME
-        if "SCH" in source_df.columns:
-            source_df = source_df.with_columns(
-                pl.concat_str([pl.col("SCH"), pl.lit("."), pl.col("TABLE_NAME")]).alias(
-                    "SCH_TABLE"
-                )
+    for df_ref, name in [(source_df, "source"), (target_df, "target")]:
+        if "DATA_TYPE" not in df_ref.columns:
+            df_ref = df_ref.with_columns(pl.lit("N/A").alias("DATA_TYPE"))
+        if name == "source":
+            source_df = df_ref
+        else:
+            target_df = df_ref
+
+    for df_ref, name in [(source_df, "source"), (target_df, "target")]:
+        if "SCH" in df_ref.columns:
+            df_ref = df_ref.with_columns(
+                pl.concat_str([pl.col("SCH"), pl.lit("."), pl.col("TABLE_NAME")]).alias("SCH_TABLE")
             )
         else:
-            source_df = source_df.with_columns(pl.col("TABLE_NAME").alias("SCH_TABLE"))
-
-        if "SCH" in target_df.columns:
-            target_df = target_df.with_columns(
-                pl.concat_str([pl.col("SCH"), pl.lit("."), pl.col("TABLE_NAME")]).alias(
-                    "SCH_TABLE"
-                )
-            )
+            df_ref = df_ref.with_columns(pl.col("TABLE_NAME").alias("SCH_TABLE"))
+        if name == "source":
+            source_df = df_ref
         else:
-            target_df = target_df.with_columns(pl.col("TABLE_NAME").alias("SCH_TABLE"))
+            target_df = df_ref
 
     return source_df, target_df
 
 
+# ---------------------------------------------------------------------------
+# Comparison logic
+# ---------------------------------------------------------------------------
+
+
 def compare_tables(source_df, target_df):
-    """Compare tables between source and target"""
+    """Compare tables between source and target."""
     source_tables = set(source_df["SCH_TABLE"].unique())
     target_tables = set(target_df["SCH_TABLE"].unique())
-
-    common_tables = source_tables.intersection(target_tables)
-    source_only = source_tables - target_tables
-    target_only = target_tables - source_tables
-
     return {
-        "common": sorted(list(common_tables)),
-        "source_only": sorted(list(source_only)),
-        "target_only": sorted(list(target_only)),
+        "common": sorted(source_tables & target_tables),
+        "source_only": sorted(source_tables - target_tables),
+        "target_only": sorted(target_tables - source_tables),
     }
 
 
 def compare_columns(source_df, target_df, table_name, type_mappings=None):
-    """Compare columns for a specific table"""
-    source_cols = source_df.filter(pl.col("SCH_TABLE") == table_name).select(
-        ["COL_NAME", "DATA_TYPE"]
-    )
-    target_cols = target_df.filter(pl.col("SCH_TABLE") == table_name).select(
-        ["COL_NAME", "DATA_TYPE"]
-    )
+    """Compare columns for a specific table."""
+    source_cols = source_df.filter(pl.col("SCH_TABLE") == table_name).select(["COL_NAME", "DATA_TYPE"])
+    target_cols = target_df.filter(pl.col("SCH_TABLE") == table_name).select(["COL_NAME", "DATA_TYPE"])
 
-    source_cols_set = set(source_cols["COL_NAME"].to_list())
-    target_cols_set = set(target_cols["COL_NAME"].to_list())
+    src_set = set(source_cols["COL_NAME"].to_list())
+    tgt_set = set(target_cols["COL_NAME"].to_list())
+    common = src_set & tgt_set
 
-    common_cols = source_cols_set.intersection(target_cols_set)
-    source_only = source_cols_set - target_cols_set
-    target_only = target_cols_set - source_cols_set
-
-    # Compare data types for common columns
-    datatype_mismatches = []
-    for col in common_cols:
-        source_type = source_cols.filter(pl.col("COL_NAME") == col)["DATA_TYPE"].item()
-        target_type = target_cols.filter(pl.col("COL_NAME") == col)["DATA_TYPE"].item()
-        if not are_types_compatible(source_type, target_type, type_mappings):
-            datatype_mismatches.append(
-                {"column": col, "source_type": source_type, "target_type": target_type}
-            )
+    mismatches = []
+    for col in common:
+        st = source_cols.filter(pl.col("COL_NAME") == col)["DATA_TYPE"].item()
+        tt = target_cols.filter(pl.col("COL_NAME") == col)["DATA_TYPE"].item()
+        if not are_types_compatible(st, tt, type_mappings):
+            mismatches.append({"column": col, "source_type": st, "target_type": tt})
 
     return {
-        "common": sorted(list(common_cols)),
-        "source_only": sorted(list(source_only)),
-        "target_only": sorted(list(target_only)),
-        "datatype_mismatches": datatype_mismatches,
+        "common": sorted(common),
+        "source_only": sorted(src_set - tgt_set),
+        "target_only": sorted(tgt_set - src_set),
+        "datatype_mismatches": mismatches,
     }
 
 
-def format_worksheet(ws):
-    """Apply formatting to worksheet"""
-    header_fill = PatternFill(
-        start_color="366092", end_color="366092", fill_type="solid"
-    )
-    header_font = Font(color="FFFFFF", bold=True)
+# ---------------------------------------------------------------------------
+# Excel report
+# ---------------------------------------------------------------------------
 
-    # Format headers
+
+def _format_worksheet(ws):
+    """Apply formatting to worksheet."""
+    header_fill = PatternFill(start_color="366092", end_color="366092", fill_type="solid")
+    header_font = Font(color="FFFFFF", bold=True)
     for cell in ws[1]:
         cell.fill = header_fill
         cell.font = header_font
         cell.alignment = Alignment(horizontal="center")
-
-    # Adjust column widths
     for column in ws.columns:
-        max_length = 0
         column = list(column)
-        for cell in column:
-            try:
-                if len(str(cell.value)) > max_length:
-                    max_length = len(str(cell.value))
-            except:
-                pass
-        # Calculate width: add 2 for padding, cap at 21.6 (3 inches)
-        # If content is smaller, use the smaller width
-        adjusted_width = min(max_length + 2, 21.6)
-        ws.column_dimensions[get_column_letter(column[0].column)].width = adjusted_width
+        max_len = max((len(str(c.value or "")) for c in column), default=0)
+        ws.column_dimensions[get_column_letter(column[0].column)].width = min(max_len + 2, 21.6)
 
 
-def create_excel_report(
-    comparison_results, source_df, target_df, file_name, type_mappings=None
-):
-    """Create formatted Excel report"""
+def create_excel_report(comparison_results, source_df, target_df, file_name, type_mappings=None):
+    """Create formatted Excel report."""
     wb = Workbook()
 
-    # Table Comparison Sheet
-    ws_tables = wb.active
-    ws_tables.title = "Table Comparison"
-    ws_tables.append(["Category", "Table Name"])
+    # --- Table Comparison ---
+    ws = wb.active
+    ws.title = "Table Comparison"
+    ws.append(["Category", "Table Name"])
+    for cat in ("common", "source_only", "target_only"):
+        label = cat.replace("_", " ").title()
+        for t in comparison_results["tables"][cat]:
+            ws.append([label, t])
+    _format_worksheet(ws)
 
-    for table in comparison_results["tables"]["common"]:
-        ws_tables.append(["Common", table])
-    for table in comparison_results["tables"]["source_only"]:
-        ws_tables.append(["Source Only", table])
-    for table in comparison_results["tables"]["target_only"]:
-        ws_tables.append(["Target Only", table])
-
-    format_worksheet(ws_tables)
-
-    # Column Comparison Sheet
-    ws_columns = wb.create_sheet("Column Comparison")
-    ws_columns.append(
-        ["Table Name", "Column Name", "Status", "Source Type", "Target Type"]
-    )
-
-    for table in comparison_results["columns"]:
-        # Get all columns from source and target for this table
-        table_name = table["table_name"]
-        source_cols = source_df.filter(pl.col("SCH_TABLE") == table_name).select(
-            ["COL_NAME", "DATA_TYPE"]
+    # --- Column Comparison ---
+    ws2 = wb.create_sheet("Column Comparison")
+    ws2.append(["Table Name", "Column Name", "Status", "Source Type", "Target Type"])
+    for tbl in comparison_results["columns"]:
+        tn = tbl["table_name"]
+        src = dict(
+            zip(
+                source_df.filter(pl.col("SCH_TABLE") == tn)["COL_NAME"],
+                source_df.filter(pl.col("SCH_TABLE") == tn)["DATA_TYPE"],
+            )
         )
-        target_cols = target_df.filter(pl.col("SCH_TABLE") == table_name).select(
-            ["COL_NAME", "DATA_TYPE"]
+        tgt = dict(
+            zip(
+                target_df.filter(pl.col("SCH_TABLE") == tn)["COL_NAME"],
+                target_df.filter(pl.col("SCH_TABLE") == tn)["DATA_TYPE"],
+            )
         )
-
-        # Create dictionaries for easy lookup
-        source_types = dict(zip(source_cols["COL_NAME"], source_cols["DATA_TYPE"]))
-        target_types = dict(zip(target_cols["COL_NAME"], target_cols["DATA_TYPE"]))
-
-        # Process all columns
-        all_columns = sorted(set(list(source_types.keys()) + list(target_types.keys())))
-
-        for col in all_columns:
-            source_type = source_types.get(col, "N/A")
-            target_type = target_types.get(col, "N/A")
-
-            if col in table["source_only"]:
+        for col in sorted(set(list(src) + list(tgt))):
+            st, tt = src.get(col, "N/A"), tgt.get(col, "N/A")
+            if col in tbl["source_only"]:
                 status = "Source Only"
-            elif col in table["target_only"]:
+            elif col in tbl["target_only"]:
                 status = "Target Only"
-            else:  # Column exists in both
-                if are_types_compatible(source_type, target_type, type_mappings):
-                    status = "Matching"
-                else:
-                    status = "Different Types"
+            elif are_types_compatible(st, tt, type_mappings):
+                status = "Matching"
+            else:
+                status = "Different Types"
+            ws2.append([tn, col, status, st, tt])
+    _format_worksheet(ws2)
 
-            ws_columns.append(
-                [table["table_name"], col, status, source_type, target_type]
-            )
+    # --- Datatype Mismatches ---
+    ws3 = wb.create_sheet("Datatype Mismatches")
+    ws3.append(["Table Name", "Column Name", "Source Type", "Target Type"])
+    for tbl in comparison_results["columns"]:
+        for m in tbl["datatype_mismatches"]:
+            ws3.append([tbl["table_name"], m["column"], m["source_type"], m["target_type"]])
+    _format_worksheet(ws3)
 
-    format_worksheet(ws_columns)
-
-    # Datatype Mismatches Sheet
-    ws_datatypes = wb.create_sheet("Datatype Mismatches")
-    ws_datatypes.append(["Table Name", "Column Name", "Source Type", "Target Type"])
-
-    for table in comparison_results["columns"]:
-        for mismatch in table["datatype_mismatches"]:
-            ws_datatypes.append(
-                [
-                    table["table_name"],
-                    mismatch["column"],
-                    mismatch["source_type"],
-                    mismatch["target_type"],
-                ]
-            )
-
-    format_worksheet(ws_datatypes)
-
-    # Save the workbook with timestamp
     os.makedirs("results", exist_ok=True)
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    if "/" in file_name:
-        file_name = file_name.split("/")[-1]
-    wb.save(f"results/{file_name}_{timestamp}.xlsx")
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    safe_name = file_name.split("/")[-1] if "/" in file_name else file_name
+    wb.save(f"results/{safe_name}_{ts}.xlsx")
+
+
+# ---------------------------------------------------------------------------
+# Core comparison runners
+# ---------------------------------------------------------------------------
+
+
+def _run_comparison(source_df, target_df, report_name, type_mappings=None):
+    """Run table/column comparison and generate Excel report."""
+    table_comparison = compare_tables(source_df, target_df)
+    column_comparisons = []
+    for tbl in table_comparison["common"]:
+        cc = compare_columns(source_df, target_df, tbl, type_mappings)
+        column_comparisons.append({"table_name": tbl, **cc})
+
+    results = {"tables": table_comparison, "columns": column_comparisons}
+    create_excel_report(results, source_df, target_df, report_name, type_mappings)
+    return results
+
+
+def colcompare_from_db(source_config_path, target_config_path, type_mappings=None):
+    """Compare column schemas by fetching metadata directly from databases."""
+    with Timer("Database column comparison"):
+        source_config = load_config(source_config_path)
+        target_config = load_config(target_config_path)
+
+        tables_file = source_config.get("tables_file") or target_config.get("tables_file")
+        if not tables_file:
+            logger.error("tables_file must be specified in at least one config")
+            return
+
+        max_workers = source_config.get("max_workers", 4)
+        df, source_tables, target_tables = _read_table_lists(tables_file)
+
+        if target_tables is None:
+            target_tables = source_tables
+
+        source_df = fetch_metadata_parallel(source_config, source_tables, "source:", max_workers)
+        target_df = fetch_metadata_parallel(target_config, target_tables, "target:", max_workers)
+
+        report_name = Path(tables_file).stem
+        _run_comparison(source_df, target_df, report_name, type_mappings)
+        logger.info("Database column comparison complete")
 
 
 def colcompare(args=None):
+    """Run column comparison from files or database connections."""
     if isinstance(args, (list, type(None))):
-        # Called from command line
         parser = argparse.ArgumentParser(
-            description="Compare column schemas between two CSV or Parquet files",
+            description="Compare column schemas between CSV/Parquet files or databases",
             formatter_class=argparse.RawDescriptionHelpFormatter,
             epilog="""
 Generates an Excel report with three sheets:
@@ -432,74 +390,44 @@ To generate a default configuration file:
   dbqt colcompare --generate-config [--output PATH]
             """,
         )
-
-        parser.add_argument(
-            "--generate-config",
-            action="store_true",
-            help="Generate a default type mappings configuration file",
-        )
-        parser.add_argument(
-            "--output",
-            "-o",
-            default="colcompare_config.yaml",
-            help="Output path for config file (used with --generate-config)",
-        )
-        parser.add_argument(
-            "source", nargs="?", help="Path to the source CSV/Parquet file"
-        )
-        parser.add_argument(
-            "target", nargs="?", help="Path to the target CSV/Parquet file"
-        )
-        parser.add_argument(
-            "--config", "-c", help="Path to type mappings configuration file"
-        )
-        parser.add_argument(
-            "--verbose", "-v", action="store_true", help="Verbose logging"
-        )
+        parser.add_argument("--generate-config", action="store_true",
+                            help="Generate a default type mappings configuration file")
+        parser.add_argument("--output", "-o", default="colcompare_config.yaml",
+                            help="Output path for config file (used with --generate-config)")
+        parser.add_argument("source", nargs="?", help="Path to the source CSV/Parquet file")
+        parser.add_argument("target", nargs="?", help="Path to the target CSV/Parquet file")
+        parser.add_argument("--source-config", help="YAML config for source database")
+        parser.add_argument("--target-config", help="YAML config for target database")
+        parser.add_argument("--config", "-c", help="Path to type mappings configuration file")
+        parser.add_argument("--verbose", "-v", action="store_true", help="Verbose logging")
 
         args = parser.parse_args(args)
-
-        # Setup logging
         setup_logging(args.verbose)
 
-        # Handle generate-config command
         if args.generate_config:
             generate_config_file(args.output)
             return
 
-        # Validate that source and target are provided for comparison
-        if not args.source or not args.target:
-            parser.error("source and target arguments are required for comparison")
+        if args.source_config and args.target_config:
+            tm = load_type_mappings(getattr(args, "config", None))
+            colcompare_from_db(args.source_config, args.target_config, tm)
+            return
 
-    # Load type mappings
+        if not args.source or not args.target:
+            parser.error(
+                "Provide source and target files, or --source-config and --target-config"
+            )
+
     type_mappings = load_type_mappings(getattr(args, "config", None))
 
     with Timer("Column comparison"):
-        # Read source and target files
         source_df, target_df = read_files(args.source, args.target)
-
-        # Compare tables
-        table_comparison = compare_tables(source_df, target_df)
-
-        # Compare columns for common tables
-        column_comparisons = []
-        for table in table_comparison["common"]:
-            column_comparison = compare_columns(
-                source_df, target_df, table, type_mappings
-            )
-            column_comparisons.append({"table_name": table, **column_comparison})
-
-        # Create comparison results dictionary
-        comparison_results = {"tables": table_comparison, "columns": column_comparisons}
         target_file_name = args.target.split(".")[0]
-        # Generate Excel report
-        create_excel_report(
-            comparison_results, source_df, target_df, target_file_name, type_mappings
-        )
+        _run_comparison(source_df, target_df, target_file_name, type_mappings)
 
 
 def main(args=None):
-    """Entry point for the colcompare tool"""
+    """Entry point for the colcompare tool."""
     colcompare(args)
 
 

--- a/dbqt/tools/colcompare.py
+++ b/dbqt/tools/colcompare.py
@@ -395,12 +395,12 @@ To generate a default configuration file:
   dbqt colcompare --generate-config [--output PATH]
             """,
         )
-        parser.add_argument("--generate-config", action="store_true",
-                            help="Generate a default type mappings configuration file")
+        parser.add_argument("--generate-col-mappings", action="store_true",
+                            help="Generate a default column type mappings configuration file")
         parser.add_argument("--output", "-o", default="colcompare_config.yaml",
                             help="Output path for config file (used with --generate-config)")
         parser.add_argument("source", nargs="?", help="Path to the source CSV/Parquet file")
-        parser.add_argument("tt", nargs="?", help="Path to the target CSV/Parquet file")
+        parser.add_argument("target", nargs="?", help="Path to the target CSV/Parquet file")
         parser.add_argument("--source-config", help="YAML config for source database")
         parser.add_argument("--target-config", help="YAML config for target database")
         parser.add_argument("--config", "-c", help="Path to type mappings configuration file")
@@ -409,7 +409,7 @@ To generate a default configuration file:
         args = parser.parse_args(args)
         setup_logging(args.verbose)
 
-        if args.generate_config:
+        if args.generate_col_mappings:
             generate_config_file(args.output)
             return
 

--- a/dbqt/tools/colcompare.py
+++ b/dbqt/tools/colcompare.py
@@ -21,6 +21,7 @@ from dbqt.tools.utils import (
     Timer,
     fetch_metadata_parallel,
     _read_table_lists,
+    discover_tables_from_db,
 )
 
 logger = logging.getLogger(__name__)
@@ -359,12 +360,10 @@ def colcompare_from_db(source_config_path, target_config_path, type_mappings=Non
         target_config = load_config(target_config_path)
 
         tables_file = source_config.get("tables_file") or target_config.get("tables_file")
-        if not tables_file:
-            logger.error("tables_file must be specified in at least one config")
-            return
-
         max_workers = source_config.get("max_workers", 4)
-        df, source_tables, target_tables = _read_table_lists(tables_file)
+        df, source_tables, target_tables = _read_table_lists(
+            tables_file, source_config, target_config
+        )
 
         if target_tables is None:
             target_tables = source_tables

--- a/dbqt/tools/colcompare.py
+++ b/dbqt/tools/colcompare.py
@@ -396,7 +396,13 @@ def colcompare_from_db(source_config_path, target_config_path, type_mappings=Non
         source_df = fetch_all_metadata_as_df(source_config, source_tables)
         target_df = fetch_all_metadata_as_df(target_config, target_tables)
 
-        report_name = Path(tables_file).stem if tables_file else "colcompare_report"
+        if tables_file:
+            report_name = Path(tables_file).stem
+        else:
+            from dbqt.tools.utils import get_schema_label
+
+            schema_label = get_schema_label(target_config)
+            report_name = f"{schema_label}_colcompare_report"
         _run_comparison(source_df, target_df, report_name, type_mappings)
         logger.info("Database column comparison complete")
 

--- a/dbqt/tools/colcompare.py
+++ b/dbqt/tools/colcompare.py
@@ -50,13 +50,28 @@ def load_type_mappings(config_path=None):
     return DEFAULT_TYPE_MAPPINGS
 
 
+def load_excluded_cols(config_path=None):
+    """Load excluded column names from YAML config file.
+
+    Returns a set of upper-cased column names that should be ignored
+    during column comparison.
+    """
+    if config_path and Path(config_path).exists():
+        with open(config_path, "r") as f:
+            config = yaml.safe_load(f)
+            raw = config.get("excluded_cols", [])
+            if raw:
+                excluded = {c.upper() for c in raw}
+                logger.info(
+                    f"Excluding {len(excluded)} columns from comparison: {excluded}"
+                )
+                return excluded
+    return set()
+
+
 def generate_config_file(output_path="colcompare_config.yaml"):
     """Generate a default configuration file with type mappings."""
-    config = {
-        "type_mappings": DEFAULT_TYPE_MAPPINGS,
-        "description": "Column comparison type mappings configuration. "
-        "Each key represents a type group, and the list contains equivalent types.",
-    }
+    config = {"type_mappings": DEFAULT_TYPE_MAPPINGS}
 
     output_file = Path(output_path)
     if output_file.exists():
@@ -67,7 +82,18 @@ def generate_config_file(output_path="colcompare_config.yaml"):
             return
 
     with open(output_path, "w") as f:
+        f.write(
+            "# Column comparison type mappings configuration.\n"
+            "# Each key represents a type group, and the list contains equivalent types.\n"
+        )
         yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+        # Append excluded_cols in block style with commented examples
+        f.write(
+            "\n# Column names to exclude from comparison (case-insensitive)\n"
+            "excluded_cols:\n"
+            "  # - CREATED_AT\n"
+            "  # - UPDATED_AT\n"
+        )
 
     logger.info(f"Generated default config file at {output_path}")
     print(f"\nDefault configuration saved to: {output_path}")
@@ -243,14 +269,27 @@ def compare_tables(source_df, target_df):
     }
 
 
-def compare_columns(source_df, target_df, table_name, type_mappings=None):
-    """Compare columns for a specific table."""
+def compare_columns(
+    source_df, target_df, table_name, type_mappings=None, excluded_cols=None
+):
+    """Compare columns for a specific table.
+
+    Parameters
+    ----------
+    excluded_cols : set[str] | None
+        Upper-cased column names to ignore during comparison.
+    """
     source_cols = source_df.filter(pl.col("SCH_TABLE") == table_name).select(
         ["COL_NAME", "DATA_TYPE"]
     )
     target_cols = target_df.filter(pl.col("SCH_TABLE") == table_name).select(
         ["COL_NAME", "DATA_TYPE"]
     )
+
+    # Apply exclusion filter
+    if excluded_cols:
+        source_cols = source_cols.filter(~pl.col("COL_NAME").is_in(list(excluded_cols)))
+        target_cols = target_cols.filter(~pl.col("COL_NAME").is_in(list(excluded_cols)))
 
     src_set = set(source_cols["COL_NAME"].to_list())
     tgt_set = set(target_cols["COL_NAME"].to_list())
@@ -295,7 +334,12 @@ def _format_worksheet(ws):
 
 
 def create_excel_report(
-    comparison_results, source_df, target_df, file_name, type_mappings=None
+    comparison_results,
+    source_df,
+    target_df,
+    file_name,
+    type_mappings=None,
+    excluded_cols=None,
 ):
     """Create formatted Excel report."""
     wb = Workbook()
@@ -328,6 +372,8 @@ def create_excel_report(
             )
         )
         for col in sorted(set(list(src) + list(tgt))):
+            if excluded_cols and col.upper() in excluded_cols:
+                continue
             st, tt = src.get(col, "N/A"), tgt.get(col, "N/A")
             if col in tbl["source_only"]:
                 status = "Source Only"
@@ -361,20 +407,26 @@ def create_excel_report(
 # ---------------------------------------------------------------------------
 
 
-def _run_comparison(source_df, target_df, report_name, type_mappings=None):
+def _run_comparison(
+    source_df, target_df, report_name, type_mappings=None, excluded_cols=None
+):
     """Run table/column comparison and generate Excel report."""
     table_comparison = compare_tables(source_df, target_df)
     column_comparisons = []
     for tbl in table_comparison["common"]:
-        cc = compare_columns(source_df, target_df, tbl, type_mappings)
+        cc = compare_columns(source_df, target_df, tbl, type_mappings, excluded_cols)
         column_comparisons.append({"table_name": tbl, **cc})
 
     results = {"tables": table_comparison, "columns": column_comparisons}
-    create_excel_report(results, source_df, target_df, report_name, type_mappings)
+    create_excel_report(
+        results, source_df, target_df, report_name, type_mappings, excluded_cols
+    )
     return results
 
 
-def colcompare_from_db(source_config_path, target_config_path, type_mappings=None):
+def colcompare_from_db(
+    source_config_path, target_config_path, type_mappings=None, excluded_cols=None
+):
     """Compare column schemas by fetching metadata directly from databases."""
     with Timer("Database column comparison"):
         source_config = load_config(source_config_path)
@@ -403,7 +455,7 @@ def colcompare_from_db(source_config_path, target_config_path, type_mappings=Non
 
             schema_label = get_schema_label(target_config)
             report_name = f"{schema_label}_colcompare_report"
-        _run_comparison(source_df, target_df, report_name, type_mappings)
+        _run_comparison(source_df, target_df, report_name, type_mappings, excluded_cols)
         logger.info("Database column comparison complete")
 
 
@@ -448,6 +500,12 @@ To generate a default configuration file:
             "--config", "-c", help="Path to type mappings configuration file"
         )
         parser.add_argument(
+            "--excluded-cols",
+            nargs="*",
+            default=None,
+            help="Column names to exclude from comparison (overrides config file)",
+        )
+        parser.add_argument(
             "--verbose", "-v", action="store_true", help="Verbose logging"
         )
 
@@ -458,9 +516,18 @@ To generate a default configuration file:
             generate_config_file(args.output)
             return
 
+        # Build excluded_cols set: CLI flag takes priority, then config file
+        config_path = getattr(args, "config", None)
+        if args.excluded_cols is not None:
+            excluded_cols = {c.upper() for c in args.excluded_cols}
+        else:
+            excluded_cols = load_excluded_cols(config_path)
+
         if args.source_config and args.target_config:
-            tm = load_type_mappings(getattr(args, "config", None))
-            colcompare_from_db(args.source_config, args.target_config, tm)
+            tm = load_type_mappings(config_path)
+            colcompare_from_db(
+                args.source_config, args.target_config, tm, excluded_cols
+            )
             return
 
         if not args.source or not args.target:
@@ -468,12 +535,20 @@ To generate a default configuration file:
                 "Provide source and target files, or --source-config and --target-config"
             )
 
-    type_mappings = load_type_mappings(getattr(args, "config", None))
+    config_path = getattr(args, "config", None)
+    type_mappings = load_type_mappings(config_path)
+    if not hasattr(args, "_excluded_cols_resolved"):
+        if getattr(args, "excluded_cols", None) is not None:
+            excluded_cols = {c.upper() for c in args.excluded_cols}
+        else:
+            excluded_cols = load_excluded_cols(config_path)
 
     with Timer("Column comparison"):
         source_df, target_df = read_files(args.source, args.target)
         target_file_name = args.target.split(".")[0]
-        _run_comparison(source_df, target_df, target_file_name, type_mappings)
+        _run_comparison(
+            source_df, target_df, target_file_name, type_mappings, excluded_cols
+        )
 
 
 def main(args=None):

--- a/dbqt/tools/colcompare.py
+++ b/dbqt/tools/colcompare.py
@@ -396,7 +396,7 @@ def colcompare_from_db(source_config_path, target_config_path, type_mappings=Non
         source_df = fetch_all_metadata_as_df(source_config, source_tables)
         target_df = fetch_all_metadata_as_df(target_config, target_tables)
 
-        report_name = Path(tables_file).stem
+        report_name = Path(tables_file).stem if tables_file else "colcompare_report"
         _run_comparison(source_df, target_df, report_name, type_mappings)
         logger.info("Database column comparison complete")
 

--- a/dbqt/tools/colcompare.py
+++ b/dbqt/tools/colcompare.py
@@ -474,7 +474,7 @@ Generates an Excel report with three sheets:
 The report is saved to ./results/ with a timestamp in the filename.
 
 To generate a default configuration file:
-  dbqt colcompare --generate-config [--output PATH]
+  dbqt colcompare --generate-col-mappings [--output PATH]
             """,
         )
         parser.add_argument(

--- a/dbqt/tools/colcompare.py
+++ b/dbqt/tools/colcompare.py
@@ -19,10 +19,8 @@ from dbqt.tools.utils import (
     load_config,
     setup_logging,
     Timer,
-    fetch_metadata_parallel,
     fetch_all_metadata_as_df,
     _read_table_lists,
-    discover_tables_from_db,
 )
 
 logger = logging.getLogger(__name__)
@@ -113,7 +111,9 @@ def _process_nested_type(field_type, parent_name="", processed_fields=None):
         if isinstance(element_type, pyarrow.lib.StructType):
             for nested_field in element_type:
                 full_name = (
-                    f"{parent_name}__{nested_field.name}" if parent_name else nested_field.name
+                    f"{parent_name}__{nested_field.name}"
+                    if parent_name
+                    else nested_field.name
                 )
                 if isinstance(
                     nested_field.type,
@@ -126,14 +126,18 @@ def _process_nested_type(field_type, parent_name="", processed_fields=None):
                 ):
                     _process_nested_type(nested_field.type, full_name, processed_fields)
                 else:
-                    processed_fields.append({"col_name": full_name, "type": str(nested_field.type)})
+                    processed_fields.append(
+                        {"col_name": full_name, "type": str(nested_field.type)}
+                    )
         else:
             processed_fields.append({"col_name": parent_name, "type": str(field_type)})
 
     elif isinstance(field_type, pyarrow.lib.StructType):
         for nested_field in field_type:
             full_name = (
-                f"{parent_name}__{nested_field.name}" if parent_name else nested_field.name
+                f"{parent_name}__{nested_field.name}"
+                if parent_name
+                else nested_field.name
             )
             if isinstance(
                 nested_field.type,
@@ -146,7 +150,9 @@ def _process_nested_type(field_type, parent_name="", processed_fields=None):
             ):
                 _process_nested_type(nested_field.type, full_name, processed_fields)
             else:
-                processed_fields.append({"col_name": full_name, "type": str(nested_field.type)})
+                processed_fields.append(
+                    {"col_name": full_name, "type": str(nested_field.type)}
+                )
 
     elif isinstance(field_type, pyarrow.lib.MapType):
         processed_fields.append({"col_name": parent_name, "type": str(field_type)})
@@ -207,7 +213,9 @@ def read_files(source_path, target_path):
     for df_ref, name in [(source_df, "source"), (target_df, "target")]:
         if "SCH" in df_ref.columns:
             df_ref = df_ref.with_columns(
-                pl.concat_str([pl.col("SCH"), pl.lit("."), pl.col("TABLE_NAME")]).alias("SCH_TABLE")
+                pl.concat_str([pl.col("SCH"), pl.lit("."), pl.col("TABLE_NAME")]).alias(
+                    "SCH_TABLE"
+                )
             )
         else:
             df_ref = df_ref.with_columns(pl.col("TABLE_NAME").alias("SCH_TABLE"))
@@ -237,8 +245,12 @@ def compare_tables(source_df, target_df):
 
 def compare_columns(source_df, target_df, table_name, type_mappings=None):
     """Compare columns for a specific table."""
-    source_cols = source_df.filter(pl.col("SCH_TABLE") == table_name).select(["COL_NAME", "DATA_TYPE"])
-    target_cols = target_df.filter(pl.col("SCH_TABLE") == table_name).select(["COL_NAME", "DATA_TYPE"])
+    source_cols = source_df.filter(pl.col("SCH_TABLE") == table_name).select(
+        ["COL_NAME", "DATA_TYPE"]
+    )
+    target_cols = target_df.filter(pl.col("SCH_TABLE") == table_name).select(
+        ["COL_NAME", "DATA_TYPE"]
+    )
 
     src_set = set(source_cols["COL_NAME"].to_list())
     tgt_set = set(target_cols["COL_NAME"].to_list())
@@ -266,7 +278,9 @@ def compare_columns(source_df, target_df, table_name, type_mappings=None):
 
 def _format_worksheet(ws):
     """Apply formatting to worksheet."""
-    header_fill = PatternFill(start_color="366092", end_color="366092", fill_type="solid")
+    header_fill = PatternFill(
+        start_color="366092", end_color="366092", fill_type="solid"
+    )
     header_font = Font(color="FFFFFF", bold=True)
     for cell in ws[1]:
         cell.fill = header_fill
@@ -275,10 +289,14 @@ def _format_worksheet(ws):
     for column in ws.columns:
         column = list(column)
         max_len = max((len(str(c.value or "")) for c in column), default=0)
-        ws.column_dimensions[get_column_letter(column[0].column)].width = min(max_len + 2, 21.6)
+        ws.column_dimensions[get_column_letter(column[0].column)].width = min(
+            max_len + 2, 21.6
+        )
 
 
-def create_excel_report(comparison_results, source_df, target_df, file_name, type_mappings=None):
+def create_excel_report(
+    comparison_results, source_df, target_df, file_name, type_mappings=None
+):
     """Create formatted Excel report."""
     wb = Workbook()
 
@@ -327,7 +345,9 @@ def create_excel_report(comparison_results, source_df, target_df, file_name, typ
     ws3.append(["Table Name", "Column Name", "Source Type", "Target Type"])
     for tbl in comparison_results["columns"]:
         for m in tbl["datatype_mismatches"]:
-            ws3.append([tbl["table_name"], m["column"], m["source_type"], m["target_type"]])
+            ws3.append(
+                [tbl["table_name"], m["column"], m["source_type"], m["target_type"]]
+            )
     _format_worksheet(ws3)
 
     os.makedirs("results", exist_ok=True)
@@ -360,7 +380,9 @@ def colcompare_from_db(source_config_path, target_config_path, type_mappings=Non
         source_config = load_config(source_config_path)
         target_config = load_config(target_config_path)
 
-        tables_file = source_config.get("tables_file") or target_config.get("tables_file")
+        tables_file = source_config.get("tables_file") or target_config.get(
+            "tables_file"
+        )
         max_workers = source_config.get("max_workers", 4)
         df, source_tables, target_tables = _read_table_lists(
             tables_file, source_config, target_config
@@ -397,16 +419,31 @@ To generate a default configuration file:
   dbqt colcompare --generate-config [--output PATH]
             """,
         )
-        parser.add_argument("--generate-col-mappings", action="store_true",
-                            help="Generate a default column type mappings configuration file")
-        parser.add_argument("--output", "-o", default="colcompare_config.yaml",
-                            help="Output path for config file (used with --generate-config)")
-        parser.add_argument("source", nargs="?", help="Path to the source CSV/Parquet file")
-        parser.add_argument("target", nargs="?", help="Path to the target CSV/Parquet file")
+        parser.add_argument(
+            "--generate-col-mappings",
+            action="store_true",
+            help="Generate a default column type mappings configuration file",
+        )
+        parser.add_argument(
+            "--output",
+            "-o",
+            default="colcompare_config.yaml",
+            help="Output path for config file (used with --generate-config)",
+        )
+        parser.add_argument(
+            "source", nargs="?", help="Path to the source CSV/Parquet file"
+        )
+        parser.add_argument(
+            "target", nargs="?", help="Path to the target CSV/Parquet file"
+        )
         parser.add_argument("--source-config", help="YAML config for source database")
         parser.add_argument("--target-config", help="YAML config for target database")
-        parser.add_argument("--config", "-c", help="Path to type mappings configuration file")
-        parser.add_argument("--verbose", "-v", action="store_true", help="Verbose logging")
+        parser.add_argument(
+            "--config", "-c", help="Path to type mappings configuration file"
+        )
+        parser.add_argument(
+            "--verbose", "-v", action="store_true", help="Verbose logging"
+        )
 
         args = parser.parse_args(args)
         setup_logging(args.verbose)

--- a/dbqt/tools/colcompare.py
+++ b/dbqt/tools/colcompare.py
@@ -20,6 +20,7 @@ from dbqt.tools.utils import (
     setup_logging,
     Timer,
     fetch_metadata_parallel,
+    fetch_all_metadata_as_df,
     _read_table_lists,
     discover_tables_from_db,
 )
@@ -368,8 +369,10 @@ def colcompare_from_db(source_config_path, target_config_path, type_mappings=Non
         if target_tables is None:
             target_tables = source_tables
 
-        source_df = fetch_metadata_parallel(source_config, source_tables, "source:", max_workers)
-        target_df = fetch_metadata_parallel(target_config, target_tables, "target:", max_workers)
+        # Fetch all column metadata per schema in a single query each,
+        # then filter to only the tables we care about.
+        source_df = fetch_all_metadata_as_df(source_config, source_tables)
+        target_df = fetch_all_metadata_as_df(target_config, target_tables)
 
         report_name = Path(tables_file).stem
         _run_comparison(source_df, target_df, report_name, type_mappings)

--- a/dbqt/tools/colcompare.py
+++ b/dbqt/tools/colcompare.py
@@ -410,8 +410,6 @@ To generate a default configuration file:
         setup_logging(args.verbose)
 
         if args.generate_config:
-            from dbqt.tools.colcompare import generate_config_file
-
             generate_config_file(args.output)
             return
 

--- a/dbqt/tools/colcompare.py
+++ b/dbqt/tools/colcompare.py
@@ -15,8 +15,13 @@ from openpyxl import Workbook
 from openpyxl.styles import PatternFill, Font, Alignment
 from openpyxl.utils import get_column_letter
 
-from dbqt.tools.utils import load_config, setup_logging, Timer
-from dbqt.tools.dbstats import fetch_metadata_parallel, _read_table_lists
+from dbqt.tools.utils import (
+    load_config,
+    setup_logging,
+    Timer,
+    fetch_metadata_parallel,
+    _read_table_lists,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/dbqt/tools/colcompare.py
+++ b/dbqt/tools/colcompare.py
@@ -400,7 +400,7 @@ To generate a default configuration file:
         parser.add_argument("--output", "-o", default="colcompare_config.yaml",
                             help="Output path for config file (used with --generate-config)")
         parser.add_argument("source", nargs="?", help="Path to the source CSV/Parquet file")
-        parser.add_argument("target", nargs="?", help="Path to the target CSV/Parquet file")
+        parser.add_argument("tt", nargs="?", help="Path to the target CSV/Parquet file")
         parser.add_argument("--source-config", help="YAML config for source database")
         parser.add_argument("--target-config", help="YAML config for target database")
         parser.add_argument("--config", "-c", help="Path to type mappings configuration file")

--- a/dbqt/tools/dbstats.py
+++ b/dbqt/tools/dbstats.py
@@ -33,7 +33,7 @@ def _load_configs(config_path, source_config_path, target_config_path):
     elif config_path:
         config = load_config(config_path)
         source_config = target_config = config
-        tables_file = config["tables_file"]
+        tables_file = config.get("tables_file")
         max_workers = config.get("max_workers", 4)
     else:
         raise ValueError(
@@ -70,7 +70,9 @@ def get_table_stats(
         source_config, target_config, tables_file, max_workers = _load_configs(
             config_path, source_config_path, target_config_path
         )
-        df, source_tables, target_tables = _read_table_lists(tables_file)
+        df, source_tables, target_tables = _read_table_lists(
+            tables_file, source_config, target_config
+        )
 
         if target_tables is not None:
             # source/target mode

--- a/dbqt/tools/dbstats.py
+++ b/dbqt/tools/dbstats.py
@@ -1,16 +1,62 @@
+"""Database statistics tool — row counts with optional column comparison."""
+
 import polars as pl
 import logging
 import threading
+
 from dbqt.tools.utils import load_config, ConnectionPool, setup_logging, Timer
 
 logger = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_configs(config_path, source_config_path, target_config_path):
+    """Return (source_config, target_config, tables_file, max_workers)."""
+    if source_config_path and target_config_path:
+        source_config = load_config(source_config_path)
+        target_config = load_config(target_config_path)
+        tables_file = source_config.get("tables_file") or target_config.get("tables_file")
+        max_workers = source_config.get("max_workers", 4)
+    elif config_path:
+        config = load_config(config_path)
+        source_config = target_config = config
+        tables_file = config["tables_file"]
+        max_workers = config.get("max_workers", 4)
+    else:
+        raise ValueError(
+            "Either config_path or both source/target config paths must be provided"
+        )
+    return source_config, target_config, tables_file, max_workers
+
+
+def _read_table_lists(tables_file):
+    """Read the tables CSV and return (df, source_tables, target_tables).
+
+    Returns target_tables=None when the CSV uses a single 'table_name' column.
+    """
+    df = pl.read_csv(tables_file)
+    if "source_table" in df.columns and "target_table" in df.columns:
+        return df, df["source_table"].to_list(), df["target_table"].to_list()
+    elif "table_name" in df.columns:
+        return df, df["table_name"].to_list(), None
+    else:
+        raise ValueError(
+            "CSV must contain 'table_name' or 'source_table'/'target_table' columns."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Row-count functionality
+# ---------------------------------------------------------------------------
+
+
 def get_row_count_for_table(connector, table_name, prefix=""):
     """Get row count for a single table using a shared connector."""
-    # Set a more descriptive thread name
     threading.current_thread().name = f"Table-{prefix}{table_name}"
-
     try:
         count = connector.count_rows(table_name)
         logger.info(f"Table {prefix}{table_name}: {count} rows")
@@ -22,165 +68,185 @@ def get_row_count_for_table(connector, table_name, prefix=""):
 
 
 def get_table_stats(
-    config_path: str, source_config_path: str = None, target_config_path: str = None
+    config_path: str = None,
+    source_config_path: str = None,
+    target_config_path: str = None,
 ):
+    """Collect row counts for tables listed in a CSV file."""
     with Timer("Database statistics collection"):
-        # Load config(s)
-        if source_config_path and target_config_path:
-            # Two separate configs for source and target
-            source_config = load_config(source_config_path)
-            target_config = load_config(target_config_path)
-            # Use tables_file from source config (or target if not in source)
-            tables_file = source_config.get("tables_file") or target_config.get(
-                "tables_file"
-            )
-            max_workers = source_config.get("max_workers", 4)
-        else:
-            # Single config for both source and target
-            config = load_config(config_path)
-            source_config = target_config = config
-            tables_file = config["tables_file"]
-            max_workers = config.get("max_workers", 4)
+        source_config, target_config, tables_file, max_workers = _load_configs(
+            config_path, source_config_path, target_config_path
+        )
+        df, source_tables, target_tables = _read_table_lists(tables_file)
 
-        # Read tables CSV using polars
-        df = pl.read_csv(tables_file)
-
-        if "source_table" in df.columns and "target_table" in df.columns:
-            source_tables = df["source_table"].to_list()
-            target_tables = df["target_table"].to_list()
-
-            # Limit workers to number of tables to avoid creating unnecessary connections
+        if target_tables is not None:
+            # source/target mode
             source_workers = min(max_workers, len(source_tables))
             target_workers = min(max_workers, len(target_tables))
 
-            # Process source and target tables separately with their respective configs
-            with ConnectionPool(source_config, source_workers) as source_pool:
-                source_results = source_pool.execute_parallel(
-                    lambda connector, table: get_row_count_for_table(
-                        connector, table, "source:"
-                    ),
+            with ConnectionPool(source_config, source_workers) as pool:
+                source_results = pool.execute_parallel(
+                    lambda c, t: get_row_count_for_table(c, t, "source:"),
                     source_tables,
                 )
-
-            with ConnectionPool(target_config, target_workers) as target_pool:
-                target_results = target_pool.execute_parallel(
-                    lambda connector, table: get_row_count_for_table(
-                        connector, table, "target:"
-                    ),
+            with ConnectionPool(target_config, target_workers) as pool:
+                target_results = pool.execute_parallel(
+                    lambda c, t: get_row_count_for_table(c, t, "target:"),
                     target_tables,
                 )
 
-            # Separate row counts and error messages
-            source_row_counts = []
-            source_notes = []
-            target_row_counts = []
-            target_notes = []
-
-            for table in source_tables:
-                count, error = source_results[table]
-                source_row_counts.append(count)
-                source_notes.append(error)
-
-            for table in target_tables:
-                count, error = target_results[table]
-                target_row_counts.append(count)
-                target_notes.append(error)
+            src_counts, src_notes, tgt_counts, tgt_notes = [], [], [], []
+            for t in source_tables:
+                c, e = source_results[t]
+                src_counts.append(c)
+                src_notes.append(e)
+            for t in target_tables:
+                c, e = target_results[t]
+                tgt_counts.append(c)
+                tgt_notes.append(e)
 
             df = df.with_columns(
-                pl.Series("source_row_count", source_row_counts),
-                pl.Series("source_notes", source_notes),
-                pl.Series("target_row_count", target_row_counts),
-                pl.Series("target_notes", target_notes),
+                pl.Series("source_row_count", src_counts),
+                pl.Series("source_notes", src_notes),
+                pl.Series("target_row_count", tgt_counts),
+                pl.Series("target_notes", tgt_notes),
             )
-            cols = df.columns
 
             # Reorder columns
-            source_rc_col = cols.pop(cols.index("source_row_count"))
-            source_notes_col = cols.pop(cols.index("source_notes"))
-            target_rc_col = cols.pop(cols.index("target_row_count"))
-            target_notes_col = cols.pop(cols.index("target_notes"))
-
-            cols.insert(cols.index("source_table") + 1, source_rc_col)
-            cols.insert(cols.index("source_table") + 2, source_notes_col)
-            cols.insert(cols.index("target_table") + 1, target_rc_col)
-            cols.insert(cols.index("target_table") + 2, target_notes_col)
+            cols = df.columns
+            for col_name, anchor, offset in [
+                ("source_row_count", "source_table", 1),
+                ("source_notes", "source_table", 2),
+                ("target_row_count", "target_table", 1),
+                ("target_notes", "target_table", 2),
+            ]:
+                cols.pop(cols.index(col_name))
+                cols.insert(cols.index(anchor) + offset, col_name)
             df = df.select(cols)
 
-            # Add difference and percentage difference columns
             df = df.with_columns(
-                (pl.col("target_row_count") - pl.col("source_row_count")).alias(
-                    "difference"
-                )
+                (pl.col("target_row_count") - pl.col("source_row_count")).alias("difference")
             )
             df = df.with_columns(
                 (((pl.col("difference") / pl.col("source_row_count")) * 100))
                 .fill_nan(0.0)
                 .alias("percentage_difference")
             )
-
-        elif "table_name" in df.columns:
-            table_names = df["table_name"].to_list()
-
-            # Limit workers to number of tables to avoid creating unnecessary connections
-            actual_workers = min(max_workers, len(table_names))
-
-            with ConnectionPool(source_config, actual_workers) as pool:
-                # Execute parallel processing
-                results = pool.execute_parallel(get_row_count_for_table, table_names)
-
-            # Separate row counts and error messages
-            ordered_row_counts = []
-            ordered_notes = []
-
-            for table_name in table_names:
-                count, error = results[table_name]
-                ordered_row_counts.append(count)
-                ordered_notes.append(error)
-
-            # Add row counts and notes to dataframe
-            df = df.with_columns(
-                pl.Series("row_count", ordered_row_counts),
-                pl.Series("notes", ordered_notes),
-            )
         else:
-            logger.error(
-                "CSV file must contain either 'table_name' column or 'source_table' and 'target_table' columns."
+            # single-table mode
+            actual_workers = min(max_workers, len(source_tables))
+            with ConnectionPool(source_config, actual_workers) as pool:
+                results = pool.execute_parallel(get_row_count_for_table, source_tables)
+
+            counts, notes = [], []
+            for t in source_tables:
+                c, e = results[t]
+                counts.append(c)
+                notes.append(e)
+
+            df = df.with_columns(
+                pl.Series("row_count", counts),
+                pl.Series("notes", notes),
             )
-            return
 
         df.write_csv(tables_file)
-
         logger.info(f"Updated row counts in {tables_file}")
+
+
+# ---------------------------------------------------------------------------
+# Metadata retrieval (shared with colcompare)
+# ---------------------------------------------------------------------------
+
+
+def get_metadata_for_table(connector, table_name, prefix=""):
+    """Fetch column metadata for a single table via fetch_table_metadata."""
+    threading.current_thread().name = f"Meta-{prefix}{table_name}"
+    try:
+        metadata = connector.fetch_table_metadata(table_name)
+        logger.info(f"Table {prefix}{table_name}: {len(metadata)} columns")
+        return table_name, (metadata, None)
+    except Exception as e:
+        error_msg = str(e)
+        logger.error(f"Error getting metadata for {prefix}{table_name}: {error_msg}")
+        return table_name, (None, error_msg)
+
+
+def metadata_to_df(results, table_names):
+    """Convert metadata results dict into a Polars DataFrame."""
+    rows = []
+    for table_name in table_names:
+        metadata, error = results[table_name]
+        if metadata is None:
+            continue
+        for col_row in metadata:
+            rows.append(
+                {
+                    "SCH_TABLE": table_name,
+                    "COL_NAME": str(col_row[0]).upper(),
+                    "DATA_TYPE": str(col_row[1]).upper() if col_row[1] else "N/A",
+                    "DATETIME_PRECISION": col_row[2] if len(col_row) > 2 else None,
+                    "NUMERIC_PRECISION": col_row[3] if len(col_row) > 3 else None,
+                    "NUMERIC_SCALE": col_row[4] if len(col_row) > 4 else None,
+                }
+            )
+    if not rows:
+        return pl.DataFrame(
+            schema={
+                "SCH_TABLE": pl.Utf8,
+                "COL_NAME": pl.Utf8,
+                "DATA_TYPE": pl.Utf8,
+                "DATETIME_PRECISION": pl.Int64,
+                "NUMERIC_PRECISION": pl.Int64,
+                "NUMERIC_SCALE": pl.Int64,
+            }
+        )
+    return pl.DataFrame(rows)
+
+
+def fetch_metadata_parallel(config, table_names, prefix="", max_workers=4):
+    """Fetch metadata for many tables in parallel, return a Polars DataFrame."""
+    workers = min(max_workers, len(table_names))
+    with ConnectionPool(config, workers) as pool:
+        results = pool.execute_parallel(
+            lambda c, t: get_metadata_for_table(c, t, prefix),
+            table_names,
+        )
+    return metadata_to_df(results, table_names)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
 
 
 def main(args=None):
     import argparse
 
     parser = argparse.ArgumentParser(
-        description="Get row counts for database tables specified in a config file",
+        description="Database statistics: row counts and/or column comparison",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
-Example config.yaml:
-    connection:
-        type: Snowflake
-        user: myuser
-        password: mypass
-        host: myorg.snowflakecomputing.com
-    tables_file: tables.csv
+Modes:
+  rowcount   - Get row counts for tables (default)
+  colcompare - Compare column schemas between source and target
+  both       - Run row counts then column comparison
+
+Examples:
+  dbqt dbstats --config config.yaml
+  dbqt dbstats colcompare --source-config src.yaml --target-config tgt.yaml
+  dbqt dbstats both --source-config src.yaml --target-config tgt.yaml
         """,
     )
     parser.add_argument(
-        "--config",
-        help="YAML config file containing database connection and tables list (used for both source and target if --source-config and --target-config not provided)",
+        "mode",
+        nargs="?",
+        default="rowcount",
+        choices=["rowcount", "colcompare", "both"],
+        help="Operation mode (default: rowcount)",
     )
-    parser.add_argument(
-        "--source-config",
-        help="YAML config file for source database connection",
-    )
-    parser.add_argument(
-        "--target-config",
-        help="YAML config file for target database connection",
-    )
+    parser.add_argument("--config", help="YAML config (used as both source and target)")
+    parser.add_argument("--source-config", help="YAML config for source database")
+    parser.add_argument("--target-config", help="YAML config for target database")
     parser.add_argument("--verbose", "-v", action="store_true", help="Verbose logging")
 
     if args is None:
@@ -190,17 +256,33 @@ Example config.yaml:
 
     setup_logging(args.verbose)
 
-    # Validate arguments
-    if args.source_config and args.target_config:
-        # Two-config mode
-        get_table_stats(None, args.source_config, args.target_config)
-    elif args.config:
-        # Single-config mode
-        get_table_stats(args.config)
-    else:
-        parser.error(
-            "Either --config or both --source-config and --target-config must be provided"
-        )
+    mode = args.mode
+
+    if mode in ("rowcount", "both"):
+        if args.source_config and args.target_config:
+            get_table_stats(
+                source_config_path=args.source_config,
+                target_config_path=args.target_config,
+            )
+        elif args.config:
+            get_table_stats(config_path=args.config)
+        else:
+            parser.error(
+                "Either --config or both --source-config and --target-config required"
+            )
+
+    if mode in ("colcompare", "both"):
+        # Delegate to colcompare module to avoid circular imports
+        from dbqt.tools.colcompare import colcompare_from_db
+
+        if args.source_config and args.target_config:
+            colcompare_from_db(args.source_config, args.target_config)
+        elif args.config:
+            colcompare_from_db(args.config, args.config)
+        else:
+            parser.error(
+                "Either --config or both --source-config and --target-config required"
+            )
 
 
 if __name__ == "__main__":

--- a/dbqt/tools/dbstats.py
+++ b/dbqt/tools/dbstats.py
@@ -4,7 +4,16 @@ import polars as pl
 import logging
 import threading
 
-from dbqt.tools.utils import load_config, ConnectionPool, setup_logging, Timer
+from dbqt.tools.utils import (
+    load_config,
+    ConnectionPool,
+    setup_logging,
+    Timer,
+    _read_table_lists,
+    get_metadata_for_table,
+    metadata_to_df,
+    fetch_metadata_parallel,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -31,22 +40,6 @@ def _load_configs(config_path, source_config_path, target_config_path):
             "Either config_path or both source/target config paths must be provided"
         )
     return source_config, target_config, tables_file, max_workers
-
-
-def _read_table_lists(tables_file):
-    """Read the tables CSV and return (df, source_tables, target_tables).
-
-    Returns target_tables=None when the CSV uses a single 'table_name' column.
-    """
-    df = pl.read_csv(tables_file)
-    if "source_table" in df.columns and "target_table" in df.columns:
-        return df, df["source_table"].to_list(), df["target_table"].to_list()
-    elif "table_name" in df.columns:
-        return df, df["table_name"].to_list(), None
-    else:
-        raise ValueError(
-            "CSV must contain 'table_name' or 'source_table'/'target_table' columns."
-        )
 
 
 # ---------------------------------------------------------------------------
@@ -151,67 +144,6 @@ def get_table_stats(
 
         df.write_csv(tables_file)
         logger.info(f"Updated row counts in {tables_file}")
-
-
-# ---------------------------------------------------------------------------
-# Metadata retrieval (shared with colcompare)
-# ---------------------------------------------------------------------------
-
-
-def get_metadata_for_table(connector, table_name, prefix=""):
-    """Fetch column metadata for a single table via fetch_table_metadata."""
-    threading.current_thread().name = f"Meta-{prefix}{table_name}"
-    try:
-        metadata = connector.fetch_table_metadata(table_name)
-        logger.info(f"Table {prefix}{table_name}: {len(metadata)} columns")
-        return table_name, (metadata, None)
-    except Exception as e:
-        error_msg = str(e)
-        logger.error(f"Error getting metadata for {prefix}{table_name}: {error_msg}")
-        return table_name, (None, error_msg)
-
-
-def metadata_to_df(results, table_names):
-    """Convert metadata results dict into a Polars DataFrame."""
-    rows = []
-    for table_name in table_names:
-        metadata, error = results[table_name]
-        if metadata is None:
-            continue
-        for col_row in metadata:
-            rows.append(
-                {
-                    "SCH_TABLE": table_name,
-                    "COL_NAME": str(col_row[0]).upper(),
-                    "DATA_TYPE": str(col_row[1]).upper() if col_row[1] else "N/A",
-                    "DATETIME_PRECISION": col_row[2] if len(col_row) > 2 else None,
-                    "NUMERIC_PRECISION": col_row[3] if len(col_row) > 3 else None,
-                    "NUMERIC_SCALE": col_row[4] if len(col_row) > 4 else None,
-                }
-            )
-    if not rows:
-        return pl.DataFrame(
-            schema={
-                "SCH_TABLE": pl.Utf8,
-                "COL_NAME": pl.Utf8,
-                "DATA_TYPE": pl.Utf8,
-                "DATETIME_PRECISION": pl.Int64,
-                "NUMERIC_PRECISION": pl.Int64,
-                "NUMERIC_SCALE": pl.Int64,
-            }
-        )
-    return pl.DataFrame(rows)
-
-
-def fetch_metadata_parallel(config, table_names, prefix="", max_workers=4):
-    """Fetch metadata for many tables in parallel, return a Polars DataFrame."""
-    workers = min(max_workers, len(table_names))
-    with ConnectionPool(config, workers) as pool:
-        results = pool.execute_parallel(
-            lambda c, t: get_metadata_for_table(c, t, prefix),
-            table_names,
-        )
-    return metadata_to_df(results, table_names)
 
 
 # ---------------------------------------------------------------------------

--- a/dbqt/tools/dbstats.py
+++ b/dbqt/tools/dbstats.py
@@ -182,9 +182,9 @@ Examples:
     parser.add_argument("--target-config", help="YAML config for target database")
     parser.add_argument("--type-config", help="Path to type mappings config file (colcompare mode)")
     parser.add_argument(
-        "--generate-config",
+        "--generate-col-mappings",
         action="store_true",
-        help="Generate a default type mappings configuration file",
+        help="Generate a default column type mappings configuration file",
     )
     parser.add_argument(
         "--output", "-o",
@@ -200,7 +200,7 @@ Examples:
 
     setup_logging(args.verbose)
 
-    if args.generate_config:
+    if args.generate_col_mappings:
         generate_config_file(args.output)
         return
 

--- a/dbqt/tools/dbstats.py
+++ b/dbqt/tools/dbstats.py
@@ -200,6 +200,8 @@ Examples:
     setup_logging(args.verbose)
 
     if args.generate_config:
+        from dbqt.tools.colcompare import generate_config_file
+
         generate_config_file(args.output)
         return
 

--- a/dbqt/tools/dbstats.py
+++ b/dbqt/tools/dbstats.py
@@ -76,29 +76,72 @@ def get_table_stats(
 
         if target_tables is not None:
             # source/target mode
-            source_workers = min(max_workers, len(source_tables))
-            target_workers = min(max_workers, len(target_tables))
 
-            with ConnectionPool(source_config, source_workers) as pool:
-                source_results = pool.execute_parallel(
-                    lambda c, t: get_row_count_for_table(c, t, "source:"),
-                    source_tables,
-                )
-            with ConnectionPool(target_config, target_workers) as pool:
-                target_results = pool.execute_parallel(
-                    lambda c, t: get_row_count_for_table(c, t, "target:"),
-                    target_tables,
-                )
+            # Determine which tables to actually count based on discovery status
+            discovery_status = {}
+            if "_discovery_status" in df.columns:
+                for row in df.iter_rows(named=True):
+                    status = row["_discovery_status"]
+                    discovery_status[row["source_table"]] = status
+
+            # Filter to tables that should actually be counted
+            source_tables_to_count = [
+                t for t in source_tables
+                if discovery_status.get(t, "common") in ("common", "source_only_count")
+                and discovery_status.get(t, "common") != "target_only"
+                and discovery_status.get(t, "common") != "source_only"
+            ]
+            target_tables_to_count = [
+                t for t in target_tables
+                if discovery_status.get(t, "common") in ("common", "target_only_count")
+                and discovery_status.get(t, "common") != "source_only"
+                and discovery_status.get(t, "common") != "target_only"
+            ]
+
+            source_results = {}
+            target_results = {}
+
+            if source_tables_to_count:
+                source_workers = min(max_workers, len(source_tables_to_count))
+                with ConnectionPool(source_config, source_workers) as pool:
+                    source_results = pool.execute_parallel(
+                        lambda c, t: get_row_count_for_table(c, t, "source:"),
+                        source_tables_to_count,
+                    )
+
+            if target_tables_to_count:
+                target_workers = min(max_workers, len(target_tables_to_count))
+                with ConnectionPool(target_config, target_workers) as pool:
+                    target_results = pool.execute_parallel(
+                        lambda c, t: get_row_count_for_table(c, t, "target:"),
+                        target_tables_to_count,
+                    )
 
             src_counts, src_notes, tgt_counts, tgt_notes = [], [], [], []
             for t in source_tables:
-                c, e = source_results[t]
-                src_counts.append(c)
-                src_notes.append(e)
+                status = discovery_status.get(t, "common")
+                if status == "source_only":
+                    src_counts.append(None)
+                    src_notes.append("Only in source, row count skipped")
+                elif status == "target_only":
+                    src_counts.append(None)
+                    src_notes.append("Only in target, row count skipped")
+                else:
+                    c, e = source_results[t]
+                    src_counts.append(c)
+                    src_notes.append(e)
             for t in target_tables:
-                c, e = target_results[t]
-                tgt_counts.append(c)
-                tgt_notes.append(e)
+                status = discovery_status.get(t, "common")
+                if status == "target_only":
+                    tgt_counts.append(None)
+                    tgt_notes.append("Only in target, row count skipped")
+                elif status == "source_only":
+                    tgt_counts.append(None)
+                    tgt_notes.append("Only in source, row count skipped")
+                else:
+                    c, e = target_results[t]
+                    tgt_counts.append(c)
+                    tgt_notes.append(e)
 
             df = df.with_columns(
                 pl.Series("source_row_count", src_counts),
@@ -144,8 +187,13 @@ def get_table_stats(
                 pl.Series("notes", notes),
             )
 
-        df.write_csv(tables_file)
-        logger.info(f"Updated row counts in {tables_file}")
+        # Drop internal columns before writing
+        if "_discovery_status" in df.columns:
+            df = df.drop("_discovery_status")
+
+        output_file = tables_file if tables_file else "dbqt_table_stats.csv"
+        df.write_csv(output_file)
+        logger.info(f"Updated row counts in {output_file}")
 
 
 # ---------------------------------------------------------------------------

--- a/dbqt/tools/dbstats.py
+++ b/dbqt/tools/dbstats.py
@@ -191,7 +191,14 @@ def get_table_stats(
         if "_discovery_status" in df.columns:
             df = df.drop("_discovery_status")
 
-        output_file = tables_file if tables_file else "dbqt_table_stats.csv"
+        if tables_file:
+            output_file = tables_file
+        else:
+            from dbqt.tools.utils import get_schema_label
+
+            schema_label = get_schema_label(target_config)
+            output_file = f"{schema_label}_row_count.csv"
+
         df.write_csv(output_file)
         logger.info(f"Updated row counts in {output_file}")
 

--- a/dbqt/tools/dbstats.py
+++ b/dbqt/tools/dbstats.py
@@ -153,6 +153,7 @@ def get_table_stats(
 
 def main(args=None):
     import argparse
+    from dbqt.tools.colcompare import generate_config_file, colcompare_from_db, load_type_mappings
 
     parser = argparse.ArgumentParser(
         description="Database statistics: row counts and/or column comparison",
@@ -200,8 +201,6 @@ Examples:
     setup_logging(args.verbose)
 
     if args.generate_config:
-        from dbqt.tools.colcompare import generate_config_file
-
         generate_config_file(args.output)
         return
 
@@ -221,8 +220,6 @@ Examples:
             )
 
     if mode in ("colcompare", "both"):
-        from dbqt.tools.colcompare import colcompare_from_db, load_type_mappings
-
         type_mappings = load_type_mappings(args.type_config)
         if args.source_config and args.target_config:
             colcompare_from_db(args.source_config, args.target_config, type_mappings)

--- a/dbqt/tools/dbstats.py
+++ b/dbqt/tools/dbstats.py
@@ -27,7 +27,9 @@ def _load_configs(config_path, source_config_path, target_config_path):
     if source_config_path and target_config_path:
         source_config = load_config(source_config_path)
         target_config = load_config(target_config_path)
-        tables_file = source_config.get("tables_file") or target_config.get("tables_file")
+        tables_file = source_config.get("tables_file") or target_config.get(
+            "tables_file"
+        )
         max_workers = source_config.get("max_workers", 4)
     elif config_path:
         config = load_config(config_path)
@@ -85,13 +87,15 @@ def get_table_stats(
 
             # Filter to tables that should actually be counted
             source_tables_to_count = [
-                t for t in source_tables
+                t
+                for t in source_tables
                 if discovery_status.get(t, "common") in ("common", "source_only_count")
                 and discovery_status.get(t, "common") != "target_only"
                 and discovery_status.get(t, "common") != "source_only"
             ]
             target_tables_to_count = [
-                t for t in target_tables
+                t
+                for t in target_tables
                 if discovery_status.get(t, "common") in ("common", "target_only_count")
                 and discovery_status.get(t, "common") != "source_only"
                 and discovery_status.get(t, "common") != "target_only"
@@ -163,7 +167,9 @@ def get_table_stats(
             df = df.select(cols)
 
             df = df.with_columns(
-                (pl.col("target_row_count") - pl.col("source_row_count")).alias("difference")
+                (pl.col("target_row_count") - pl.col("source_row_count")).alias(
+                    "difference"
+                )
             )
             df = df.with_columns(
                 (((pl.col("difference") / pl.col("source_row_count")) * 100))
@@ -210,7 +216,12 @@ def get_table_stats(
 
 def main(args=None):
     import argparse
-    from dbqt.tools.colcompare import generate_config_file, colcompare_from_db, load_type_mappings
+    from dbqt.tools.colcompare import (
+        generate_config_file,
+        colcompare_from_db,
+        load_type_mappings,
+        load_excluded_cols,
+    )
 
     parser = argparse.ArgumentParser(
         description="Database statistics: row counts and/or column comparison",
@@ -237,14 +248,17 @@ Examples:
     parser.add_argument("--config", help="YAML config (used as both source and target)")
     parser.add_argument("--source-config", help="YAML config for source database")
     parser.add_argument("--target-config", help="YAML config for target database")
-    parser.add_argument("--type-config", help="Path to type mappings config file (colcompare mode)")
+    parser.add_argument(
+        "--type-config", help="Path to type mappings config file (colcompare mode)"
+    )
     parser.add_argument(
         "--generate-col-mappings",
         action="store_true",
         help="Generate a default column type mappings configuration file",
     )
     parser.add_argument(
-        "--output", "-o",
+        "--output",
+        "-o",
         default="colcompare_config.yaml",
         help="Output path for generated config file",
     )
@@ -278,10 +292,13 @@ Examples:
 
     if mode in ("colcompare", "both"):
         type_mappings = load_type_mappings(args.type_config)
+        excluded_cols = load_excluded_cols(args.type_config)
         if args.source_config and args.target_config:
-            colcompare_from_db(args.source_config, args.target_config, type_mappings)
+            colcompare_from_db(
+                args.source_config, args.target_config, type_mappings, excluded_cols
+            )
         elif args.config:
-            colcompare_from_db(args.config, args.config, type_mappings)
+            colcompare_from_db(args.config, args.config, type_mappings, excluded_cols)
         else:
             parser.error(
                 "Either --config or both --source-config and --target-config required"

--- a/dbqt/tools/dbstats.py
+++ b/dbqt/tools/dbstats.py
@@ -149,7 +149,7 @@ def get_table_stats(
                 pl.Series("target_notes", tgt_notes),
             )
 
-            # Reorder columns
+            # Reorder columns so counts appear next to their table columns
             cols = df.columns
             for col_name, anchor, offset in [
                 ("source_row_count", "source_table", 1),
@@ -157,8 +157,9 @@ def get_table_stats(
                 ("target_row_count", "target_table", 1),
                 ("target_notes", "target_table", 2),
             ]:
-                cols.pop(cols.index(col_name))
-                cols.insert(cols.index(anchor) + offset, col_name)
+                if col_name in cols and anchor in cols:
+                    cols.pop(cols.index(col_name))
+                    cols.insert(cols.index(anchor) + offset, col_name)
             df = df.select(cols)
 
             df = df.with_columns(

--- a/dbqt/tools/dbstats.py
+++ b/dbqt/tools/dbstats.py
@@ -12,7 +12,6 @@ from dbqt.tools.utils import (
     _read_table_lists,
     get_metadata_for_table,
     metadata_to_df,
-    fetch_metadata_parallel,
 )
 
 logger = logging.getLogger(__name__)

--- a/dbqt/tools/dbstats.py
+++ b/dbqt/tools/dbstats.py
@@ -179,6 +179,17 @@ Examples:
     parser.add_argument("--config", help="YAML config (used as both source and target)")
     parser.add_argument("--source-config", help="YAML config for source database")
     parser.add_argument("--target-config", help="YAML config for target database")
+    parser.add_argument("--type-config", help="Path to type mappings config file (colcompare mode)")
+    parser.add_argument(
+        "--generate-config",
+        action="store_true",
+        help="Generate a default type mappings configuration file",
+    )
+    parser.add_argument(
+        "--output", "-o",
+        default="colcompare_config.yaml",
+        help="Output path for generated config file",
+    )
     parser.add_argument("--verbose", "-v", action="store_true", help="Verbose logging")
 
     if args is None:
@@ -187,6 +198,10 @@ Examples:
         args = parser.parse_args(args)
 
     setup_logging(args.verbose)
+
+    if args.generate_config:
+        generate_config_file(args.output)
+        return
 
     mode = args.mode
 
@@ -204,13 +219,13 @@ Examples:
             )
 
     if mode in ("colcompare", "both"):
-        # Delegate to colcompare module to avoid circular imports
-        from dbqt.tools.colcompare import colcompare_from_db
+        from dbqt.tools.colcompare import colcompare_from_db, load_type_mappings
 
+        type_mappings = load_type_mappings(args.type_config)
         if args.source_config and args.target_config:
-            colcompare_from_db(args.source_config, args.target_config)
+            colcompare_from_db(args.source_config, args.target_config, type_mappings)
         elif args.config:
-            colcompare_from_db(args.config, args.config)
+            colcompare_from_db(args.config, args.config, type_mappings)
         else:
             parser.error(
                 "Either --config or both --source-config and --target-config required"

--- a/dbqt/tools/utils.py
+++ b/dbqt/tools/utils.py
@@ -168,21 +168,67 @@ def format_runtime(seconds: float) -> str:
         return f"{hours}h {remaining_minutes}m {remaining_seconds:.2f}s"
 
 
-def _read_table_lists(tables_file):
+def discover_tables_from_db(config):
+    """Connect to a database and list all tables in the configured schema.
+
+    Returns a list of table name strings.
+    """
+    connector = create_connector(config["connection"])
+    connector.connect()
+    try:
+        tables = connector.list_tables()
+    finally:
+        connector.disconnect()
+    return tables
+
+
+def _read_table_lists(tables_file, source_config=None, target_config=None):
     """Read the tables CSV and return (df, source_tables, target_tables).
 
-    Returns target_tables=None when the CSV uses a single 'table_name' column.
+    If *tables_file* is ``None``, tables are auto-discovered from the database
+    schema defined in the YAML config(s).
+
+    Returns target_tables=None when operating in single-config mode.
     """
     import polars as pl
 
-    df = pl.read_csv(tables_file)
-    if "source_table" in df.columns and "target_table" in df.columns:
-        return df, df["source_table"].to_list(), df["target_table"].to_list()
-    elif "table_name" in df.columns:
-        return df, df["table_name"].to_list(), None
+    if tables_file is not None:
+        df = pl.read_csv(tables_file)
+        if "source_table" in df.columns and "target_table" in df.columns:
+            return df, df["source_table"].to_list(), df["target_table"].to_list()
+        elif "table_name" in df.columns:
+            return df, df["table_name"].to_list(), None
+        else:
+            raise ValueError(
+                "CSV must contain 'table_name' or 'source_table'/'target_table' columns."
+            )
+
+    # Auto-discover tables from database(s)
+    logger.info("No tables_file provided — discovering tables from database schema")
+
+    if source_config and target_config and source_config is not target_config:
+        source_tables = discover_tables_from_db(source_config)
+        target_tables = discover_tables_from_db(target_config)
+        df = pl.DataFrame(
+            {
+                "source_table": source_tables,
+                "target_table": target_tables,
+            }
+        ) if len(source_tables) == len(target_tables) else pl.DataFrame(
+            {"table_name": sorted(set(source_tables) | set(target_tables))}
+        )
+        if "source_table" in df.columns:
+            return df, source_tables, target_tables
+        else:
+            all_tables = df["table_name"].to_list()
+            return df, all_tables, all_tables
+    elif source_config:
+        tables = discover_tables_from_db(source_config)
+        df = pl.DataFrame({"table_name": tables})
+        return df, tables, None
     else:
         raise ValueError(
-            "CSV must contain 'table_name' or 'source_table'/'target_table' columns."
+            "Cannot discover tables: no config provided and no tables_file specified"
         )
 
 

--- a/dbqt/tools/utils.py
+++ b/dbqt/tools/utils.py
@@ -168,6 +168,20 @@ def format_runtime(seconds: float) -> str:
         return f"{hours}h {remaining_minutes}m {remaining_seconds:.2f}s"
 
 
+def get_schema_label(config):
+    """Extract a human-readable schema/database label from a YAML config.
+
+    Tries ``schema``, then ``database``, then ``sid``, falling back to
+    ``"default"``.  Used for naming output files during auto-discovery.
+    """
+    conn = config.get("connection", config)
+    for key in ("schema", "database", "sid"):
+        val = conn.get(key)
+        if val:
+            return val
+    return "default"
+
+
 def discover_tables_from_db(config):
     """Connect to a database and list all tables in the configured schema.
 

--- a/dbqt/tools/utils.py
+++ b/dbqt/tools/utils.py
@@ -195,6 +195,84 @@ def build_qualified_table_name(database, schema, table) -> str:
     return ".".join(p for p in (database, schema, table) if p)
 
 
+def _read_table_lists(tables_file):
+    """Read the tables CSV and return (df, source_tables, target_tables).
+
+    Returns target_tables=None when the CSV uses a single 'table_name' column.
+    """
+    import polars as pl
+
+    df = pl.read_csv(tables_file)
+    if "source_table" in df.columns and "target_table" in df.columns:
+        return df, df["source_table"].to_list(), df["target_table"].to_list()
+    elif "table_name" in df.columns:
+        return df, df["table_name"].to_list(), None
+    else:
+        raise ValueError(
+            "CSV must contain 'table_name' or 'source_table'/'target_table' columns."
+        )
+
+
+def get_metadata_for_table(connector, table_name, prefix=""):
+    """Fetch column metadata for a single table via fetch_table_metadata."""
+    import threading
+
+    threading.current_thread().name = f"Meta-{prefix}{table_name}"
+    try:
+        metadata = connector.fetch_table_metadata(table_name)
+        logger.info(f"Table {prefix}{table_name}: {len(metadata)} columns")
+        return table_name, (metadata, None)
+    except Exception as e:
+        error_msg = str(e)
+        logger.error(f"Error getting metadata for {prefix}{table_name}: {error_msg}")
+        return table_name, (None, error_msg)
+
+
+def metadata_to_df(results, table_names):
+    """Convert metadata results dict into a Polars DataFrame."""
+    import polars as pl
+
+    rows = []
+    for table_name in table_names:
+        metadata, error = results[table_name]
+        if metadata is None:
+            continue
+        for col_row in metadata:
+            rows.append(
+                {
+                    "SCH_TABLE": table_name,
+                    "COL_NAME": str(col_row[0]).upper(),
+                    "DATA_TYPE": str(col_row[1]).upper() if col_row[1] else "N/A",
+                    "DATETIME_PRECISION": col_row[2] if len(col_row) > 2 else None,
+                    "NUMERIC_PRECISION": col_row[3] if len(col_row) > 3 else None,
+                    "NUMERIC_SCALE": col_row[4] if len(col_row) > 4 else None,
+                }
+            )
+    if not rows:
+        return pl.DataFrame(
+            schema={
+                "SCH_TABLE": pl.Utf8,
+                "COL_NAME": pl.Utf8,
+                "DATA_TYPE": pl.Utf8,
+                "DATETIME_PRECISION": pl.Int64,
+                "NUMERIC_PRECISION": pl.Int64,
+                "NUMERIC_SCALE": pl.Int64,
+            }
+        )
+    return pl.DataFrame(rows)
+
+
+def fetch_metadata_parallel(config, table_names, prefix="", max_workers=4):
+    """Fetch metadata for many tables in parallel, return a Polars DataFrame."""
+    workers = min(max_workers, len(table_names))
+    with ConnectionPool(config, workers) as pool:
+        results = pool.execute_parallel(
+            lambda c, t: get_metadata_for_table(c, t, prefix),
+            table_names,
+        )
+    return metadata_to_df(results, table_names)
+
+
 class Timer:
     """Context manager for timing operations."""
 

--- a/dbqt/tools/utils.py
+++ b/dbqt/tools/utils.py
@@ -207,21 +207,26 @@ def _read_table_lists(tables_file, source_config=None, target_config=None):
     logger.info("No tables_file provided — discovering tables from database schema")
 
     if source_config and target_config and source_config is not target_config:
-        source_tables = discover_tables_from_db(source_config)
-        target_tables = discover_tables_from_db(target_config)
-        df = pl.DataFrame(
-            {
-                "source_table": source_tables,
-                "target_table": target_tables,
-            }
-        ) if len(source_tables) == len(target_tables) else pl.DataFrame(
-            {"table_name": sorted(set(source_tables) | set(target_tables))}
+        source_tables_set = set(discover_tables_from_db(source_config))
+        target_tables_set = set(discover_tables_from_db(target_config))
+        common = sorted(source_tables_set & target_tables_set)
+        source_only = sorted(source_tables_set - target_tables_set)
+        target_only = sorted(target_tables_set - source_tables_set)
+
+        rows = []
+        for t in common:
+            rows.append({"source_table": t, "target_table": t, "_discovery_status": "common"})
+        for t in source_only:
+            rows.append({"source_table": t, "target_table": t, "_discovery_status": "source_only"})
+        for t in target_only:
+            rows.append({"source_table": t, "target_table": t, "_discovery_status": "target_only"})
+
+        df = pl.DataFrame(rows)
+        return (
+            df,
+            df["source_table"].to_list(),
+            df["target_table"].to_list(),
         )
-        if "source_table" in df.columns:
-            return df, source_tables, target_tables
-        else:
-            all_tables = df["table_name"].to_list()
-            return df, all_tables, all_tables
     elif source_config:
         tables = discover_tables_from_db(source_config)
         df = pl.DataFrame({"table_name": tables})

--- a/dbqt/tools/utils.py
+++ b/dbqt/tools/utils.py
@@ -215,11 +215,25 @@ def _read_table_lists(tables_file, source_config=None, target_config=None):
 
         rows = []
         for t in common:
-            rows.append({"source_table": t, "target_table": t, "_discovery_status": "common"})
+            rows.append(
+                {"source_table": t, "target_table": t, "_discovery_status": "common"}
+            )
         for t in source_only:
-            rows.append({"source_table": t, "target_table": t, "_discovery_status": "source_only"})
+            rows.append(
+                {
+                    "source_table": t,
+                    "target_table": t,
+                    "_discovery_status": "source_only",
+                }
+            )
         for t in target_only:
-            rows.append({"source_table": t, "target_table": t, "_discovery_status": "target_only"})
+            rows.append(
+                {
+                    "source_table": t,
+                    "target_table": t,
+                    "_discovery_status": "target_only",
+                }
+            )
 
         df = pl.DataFrame(rows)
         return (
@@ -284,17 +298,6 @@ def metadata_to_df(results, table_names):
             }
         )
     return pl.DataFrame(rows)
-
-
-def fetch_metadata_parallel(config, table_names, prefix="", max_workers=4):
-    """Fetch metadata for many tables in parallel, return a Polars DataFrame."""
-    workers = min(max_workers, len(table_names))
-    with ConnectionPool(config, workers) as pool:
-        results = pool.execute_parallel(
-            lambda c, t: get_metadata_for_table(c, t, prefix),
-            table_names,
-        )
-    return metadata_to_df(results, table_names)
 
 
 def fetch_all_metadata_as_df(config, table_names=None):

--- a/dbqt/tools/utils.py
+++ b/dbqt/tools/utils.py
@@ -295,9 +295,21 @@ def metadata_to_df(results, table_names):
                     "SCH_TABLE": table_name,
                     "COL_NAME": str(col_row[0]).upper(),
                     "DATA_TYPE": str(col_row[1]).upper() if col_row[1] else "N/A",
-                    "DATETIME_PRECISION": col_row[2] if len(col_row) > 2 else None,
-                    "NUMERIC_PRECISION": col_row[3] if len(col_row) > 3 else None,
-                    "NUMERIC_SCALE": col_row[4] if len(col_row) > 4 else None,
+                    "DATETIME_PRECISION": (
+                        col_row[2]
+                        if len(col_row) > 2 and col_row[2] is not None
+                        else None
+                    ),
+                    "NUMERIC_PRECISION": (
+                        col_row[3]
+                        if len(col_row) > 3 and col_row[3] is not None
+                        else None
+                    ),
+                    "NUMERIC_SCALE": (
+                        col_row[4]
+                        if len(col_row) > 4 and col_row[4] is not None
+                        else None
+                    ),
                 }
             )
     if not rows:

--- a/dbqt/tools/utils.py
+++ b/dbqt/tools/utils.py
@@ -6,7 +6,11 @@ import logging
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dbqt.connections import create_connector  # noqa: F401 — re-export
+from dbqt.connections import (  # noqa: F401 — re-export
+    create_connector,
+    normalize_table_path,
+    build_qualified_table_name,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -162,37 +166,6 @@ def format_runtime(seconds: float) -> str:
         remaining_minutes = int((seconds % 3600) // 60)
         remaining_seconds = seconds % 60
         return f"{hours}h {remaining_minutes}m {remaining_seconds:.2f}s"
-
-
-def normalize_table_path(table_name: str, config: dict = None) -> tuple:
-    """Resolve a table reference into (database, schema, table) tuple.
-
-    Supports:
-      - ``table``              → (config db, config schema, table)
-      - ``schema.table``       → (config db, schema, table)
-      - ``db.schema.table``    → (db, schema, table)
-
-    Returns a 3-tuple ``(database, schema, table)`` where any component
-    may be ``None`` if it cannot be determined.
-    """
-    if config is None:
-        config = {}
-
-    parts = table_name.split(".")
-    default_db = config.get("database") or config.get("sid")
-    default_schema = config.get("schema")
-
-    if len(parts) == 3:
-        return parts[0], parts[1], parts[2]
-    elif len(parts) == 2:
-        return default_db, parts[0], parts[1]
-    else:
-        return default_db, default_schema, parts[0]
-
-
-def build_qualified_table_name(database, schema, table) -> str:
-    """Build a fully-qualified table name from resolved components, skipping Nones."""
-    return ".".join(p for p in (database, schema, table) if p)
 
 
 def _read_table_lists(tables_file):

--- a/dbqt/tools/utils.py
+++ b/dbqt/tools/utils.py
@@ -297,6 +297,56 @@ def fetch_metadata_parallel(config, table_names, prefix="", max_workers=4):
     return metadata_to_df(results, table_names)
 
 
+def fetch_all_metadata_as_df(config, table_names=None):
+    """Fetch column metadata for an entire schema in ONE query, return a Polars DataFrame.
+
+    If *table_names* is provided the result is filtered to only those tables.
+    This is much faster than ``fetch_metadata_parallel`` when many tables are
+    involved because it issues a single ``SELECT … FROM information_schema.columns``
+    (or equivalent) instead of one query per table.
+    """
+    import polars as pl
+
+    connector = create_connector(config["connection"])
+    connector.connect()
+    try:
+        raw = connector.fetch_schema_metadata()
+    finally:
+        connector.disconnect()
+
+    # raw rows: (table_name, column_name, data_type, dt_prec, num_prec, num_scale)
+    if not raw:
+        return pl.DataFrame(
+            schema={
+                "SCH_TABLE": pl.Utf8,
+                "COL_NAME": pl.Utf8,
+                "DATA_TYPE": pl.Utf8,
+                "DATETIME_PRECISION": pl.Int64,
+                "NUMERIC_PRECISION": pl.Int64,
+                "NUMERIC_SCALE": pl.Int64,
+            }
+        )
+
+    rows = [
+        {
+            "SCH_TABLE": str(r[0]).upper(),
+            "COL_NAME": str(r[1]).upper(),
+            "DATA_TYPE": str(r[2]).upper() if r[2] else "N/A",
+            "DATETIME_PRECISION": r[3],
+            "NUMERIC_PRECISION": r[4],
+            "NUMERIC_SCALE": r[5],
+        }
+        for r in raw
+    ]
+    df = pl.DataFrame(rows)
+
+    if table_names is not None:
+        upper_names = {t.upper() for t in table_names}
+        df = df.filter(pl.col("SCH_TABLE").is_in(upper_names))
+
+    return df
+
+
 class Timer:
     """Context manager for timing operations."""
 

--- a/dbqt/tools/utils.py
+++ b/dbqt/tools/utils.py
@@ -6,7 +6,7 @@ import logging
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dbqt.connections import create_connector
+from dbqt.connections import create_connector  # noqa: F401 — re-export
 
 logger = logging.getLogger(__name__)
 
@@ -162,6 +162,37 @@ def format_runtime(seconds: float) -> str:
         remaining_minutes = int((seconds % 3600) // 60)
         remaining_seconds = seconds % 60
         return f"{hours}h {remaining_minutes}m {remaining_seconds:.2f}s"
+
+
+def normalize_table_path(table_name: str, config: dict = None) -> tuple:
+    """Resolve a table reference into (database, schema, table) tuple.
+
+    Supports:
+      - ``table``              → (config db, config schema, table)
+      - ``schema.table``       → (config db, schema, table)
+      - ``db.schema.table``    → (db, schema, table)
+
+    Returns a 3-tuple ``(database, schema, table)`` where any component
+    may be ``None`` if it cannot be determined.
+    """
+    if config is None:
+        config = {}
+
+    parts = table_name.split(".")
+    default_db = config.get("database") or config.get("sid")
+    default_schema = config.get("schema")
+
+    if len(parts) == 3:
+        return parts[0], parts[1], parts[2]
+    elif len(parts) == 2:
+        return default_db, parts[0], parts[1]
+    else:
+        return default_db, default_schema, parts[0]
+
+
+def build_qualified_table_name(database, schema, table) -> str:
+    """Build a fully-qualified table name from resolved components, skipping Nones."""
+    return ".".join(p for p in (database, schema, table) if p)
 
 
 class Timer:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbqt"
-version = "0.1.17"
+version = "0.2.1"
 description = "DataBase Quality Tool"
 authors = [
     { name = "NamiLink" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbqt"
-version = "0.1.16"
+version = "0.1.17"
 description = "DataBase Quality Tool"
 authors = [
     { name = "NamiLink" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbqt"
-version = "0.1.15"
+version = "0.1.16"
 description = "DataBase Quality Tool"
 authors = [
     { name = "NamiLink" }


### PR DESCRIPTION
This release introduces database-backed column comparison, automatic table discovery, flexible table name resolution, and significant CLI changes across `colcompare` and `dbstats`. The version bumps from **0.1.15** to **0.2.1** reflecting the scope of breaking changes.

---

## BREAKING CHANGES

### CLI Flag Renames

- **`--generate-config` is now `--generate-col-mappings`** in both `dbqt colcompare` and `dbqt dbstats`. Any scripts or CI pipelines using the old flag will break.

### `fetch_table_metadata` Return Type Changed

- All database connector implementations (`DBConnector`, `MySQL`, `Snowflake`, `SQLServer`, `Oracle`) now return **5-element tuples** `(column_name, data_type, datetime_precision, numeric_precision, numeric_scale)` instead of the previous **2-element tuples** `(column_name, data_type)`. Any code consuming the output of `fetch_table_metadata` directly will need to be updated.

### `get_table_stats` Signature Changed

- The `config_path` parameter is now **optional** (keyword-only style with default `None`). Callers passing it as a positional argument will still work, but callers relying on it being required may see different behavior when omitted.

### `dbstats` Now Accepts a Positional `mode` Argument

- `dbqt dbstats` now accepts an optional positional argument: `rowcount` (default), `colcompare`, or `both`. Previously it only performed row counts. Existing invocations without a mode are unaffected, but any argument parsing wrappers should be aware of the new positional parameter.

### Internal Function Renames

- `format_worksheet` renamed to `_format_worksheet` (now private). Any external code importing this function will break.

### `get_table_columns` Error Handling Change

- `DBConnector.get_table_columns` now returns an **empty dict** `{}` on error instead of implicitly returning `None`. Callers checking for `None` as a failure indicator need to check for an empty dict instead.

---

## New Features

### Database-Backed Column Comparison

- `dbqt colcompare` now supports `--source-config` and `--target-config` flags to fetch column metadata directly from live source and target databases, eliminating the need for pre-exported CSV/Parquet schema files.
- `dbqt dbstats colcompare` and `dbqt dbstats both` provide the same capability through the dbstats entry point.

### Automatic Table Discovery

- When `tables_file` is omitted from the YAML config, DBQT will automatically discover all tables and views in the configured database schema.
- In dual-database mode, only tables present in **both** databases will have row counts collected. Tables existing in only one side are reported with a note (e.g., "Only in source, row count skipped").

### Schema-Wide Metadata Fetching

- New `fetch_schema_metadata()` method on all connectors fetches column metadata for all tables in a schema in a **single query**, dramatically improving performance for large-schema comparisons.
- New `list_tables()` method on all connectors (`MySQL`, `Snowflake`, `SQLServer`, `Oracle`, `Athena`, base `DBConnector`).

### Flexible Table Name Resolution

- Table names in CSV files now support three formats:
  - `my_table` — uses database/schema from YAML config
  - `my_schema.my_table` — overrides schema, uses database from config
  - `my_db.my_schema.my_table` — fully qualified, ignores config defaults
- Implemented via new `normalize_table_path()` and `build_qualified_table_name()` utility functions in `dbqt.connections`.

### New CLI Aliases

- `dbqt stats` is now an alias for `dbqt dbstats`.
- `dbqt rowcount` remains an alias for `dbqt dbstats`.
- `dbqt compare` remains an alias for `dbqt colcompare`.

### Column Type Mappings Generation from `dbstats`

- `dbqt dbstats --generate-col-mappings` generates the default column type mappings YAML file, same as `dbqt colcompare --generate-col-mappings`.

---

## Improvements

- **Precision metadata**: All metadata queries now retrieve `datetime_precision`, `numeric_precision`, and `numeric_scale`.
- **Error tracebacks**: `dbqt/app.py` now prints full tracebacks on tool execution errors for easier debugging.
- **Logging improvements**: Connector errors use `self.logger.error()` instead of `print()`.
- **Code refactoring**: Extracted `_run_comparison()`, `_schema_to_df()`, `_read_table_lists()`, `fetch_all_metadata_as_df()`, and other helpers to reduce duplication.
- **`.gitignore`**: Added `.cecli*` pattern.
- **README**: Removed emoji characters; updated all usage examples to reflect new CLI flags and capabilities.

---

## Files Changed

| Area | Files |
|------|-------|
| Core | `dbqt/connections.py`, `dbqt/app.py` |
| Tools | `dbqt/tools/colcompare.py`, `dbqt/tools/dbstats.py`, `dbqt/tools/utils.py`, `dbqt/tools/__init__.py` |
| Config | `pyproject.toml`, `.gitignore` |
| Docs | `README.md` |