### PR TITLE
feat: replace Excel/CSV output with interactive HTML reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ Compare schemas between databases or files:
 - Supports `table`, `schema.table`, and `db.schema.table` patterns in CSV files
 - Intelligent data type compatibility checking
 - **Customizable type mappings via YAML configuration**
-- Generates detailed Excel report with:
+- Generates interactive HTML report (powered by [Tabulator](https://tabulator.info/)) with:
   - Table differences
   - Column differences
   - Data type mismatches
-  - Formatted worksheets for easy analysis
+  - Sortable, filterable, searchable tables
+  - Built-in XLSX export button
 
 Usage:
 ```bash
@@ -127,7 +128,8 @@ Collect and analyze database statistics with multiple modes:
 - Supports separate source and target database configurations for cross-database comparisons
 - Supports `table`, `schema.table`, and `db.schema.table` patterns in CSV files
 - Automatically calculates differences and percentage changes for comparisons
-- Updates statistics in a CSV file with comprehensive error reporting
+- Generates interactive HTML reports with sortable, filterable tables
+- Built-in XLSX export from the browser
 - Configurable through YAML
 
 Usage:
@@ -182,6 +184,13 @@ tables_file: tables.csv
 
 # Optional: number of parallel workers (default: 4)
 max_workers: 10
+
+# Optional: exclude tables matching SQL-like patterns (case-insensitive)
+# % matches any sequence of characters
+excluded_tables:
+  - "%_FINAL"
+  - "TMP_%"
+  - "%_BAK_%"
 ```
 
 Example dual database configuration (for cross-database comparisons):
@@ -222,6 +231,16 @@ use those for row counts and/or column comparisons. In dual-database mode, only
 tables present in **both** databases will have row counts collected — tables that
 exist in only one side are reported with a note like *"Only in source, row count
 skipped"* since comparing a missing table is not meaningful.
+
+**Excluding tables:** Add `excluded_tables` to your YAML config to filter out
+tables by pattern. Patterns use SQL-like `%` wildcards and are case-insensitive:
+```yaml
+excluded_tables:
+  - "%_FINAL"    # any table ending in _FINAL
+  - "TMP_%"      # any table starting with TMP_
+  - "%_BAK_%"    # any table containing _BAK_
+```
+This works with both CSV-provided table lists and auto-discovered tables.
 
 Table names in the CSV support flexible path formats:
 - `my_table` — uses database/schema from YAML config

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ The tool uses intelligent type compatibility checking (e.g., `INT` and `BIGINT` 
    dbqt compare source.csv target.csv --config colcompare_config.yaml
    ```
 
+**Note:** `excluded_cols` can also be placed directly in your connection YAML configs
+(source and/or target). When running database-backed comparisons, exclusions from all
+configs are merged automatically.
+
 To generate CSV schema files from your database, run this query:
 ```sql
 SELECT
@@ -145,6 +149,9 @@ dbqt dbstats colcompare --source-config source_config.yaml --target-config targe
 
 # Both row counts and column comparison in one run
 dbqt dbstats both --source-config source_config.yaml --target-config target_config.yaml
+
+# Both mode with custom type mappings
+dbqt dbstats both --source-config source_config.yaml --target-config target_config.yaml --type-config colcompare_config.yaml
 
 # Generate a default column type mappings configuration file
 dbqt dbstats --generate-col-mappings

--- a/dbqt/tools/colcompare.py
+++ b/dbqt/tools/colcompare.py
@@ -1,9 +1,8 @@
 """Column comparison tool — compare schemas between files or databases."""
 
 import argparse
-import re
-import os
 import logging
+import re
 from datetime import datetime
 from pathlib import Path
 
@@ -11,14 +10,12 @@ import polars as pl
 import pyarrow
 import pyarrow.parquet as pq
 import yaml
-from openpyxl import Workbook
-from openpyxl.styles import PatternFill, Font, Alignment
-from openpyxl.utils import get_column_letter
 
 from dbqt.tools.utils import (
     load_config,
     setup_logging,
     Timer,
+    HTMLReport,
     fetch_all_metadata_as_df,
     _read_table_lists,
 )
@@ -31,12 +28,14 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_TYPE_MAPPINGS = {
     "INTEGER": ["INT", "INTEGER", "BIGINT", "SMALLINT", "TINYINT", "NUMBER"],
-    "VARCHAR": ["VARCHAR", "TEXT", "CHAR", "STRING", "NVARCHAR", "VARCHAR2"],
+    "VARCHAR": ["VARCHAR", "TEXT", "CHAR", "STRING", "NVARCHAR", "VARCHAR2", "ENUM"],
     "DECIMAL": ["DECIMAL", "NUMERIC", "NUMBER"],
     "FLOAT": ["FLOAT", "REAL", "DOUBLE", "DOUBLE PRECISION"],
-    "TIMESTAMP": ["TIMESTAMP", "DATETIME"],
-    "DATE": ["DATE", "TIMESTAMP"],
+    "TIMESTAMP": ["TIMESTAMP", "DATETIME", "TIMESTAMP_NTZ", "TIMESTAMP_LTZ"],
+    "DATE": ["DATE", "TIMESTAMP", "TIMESTAMP_NTZ", "TIMESTAMP_LTZ"],
+    "DATETIME": ["TIMESTAMP", "TIMESTAMP_NTZ", "TIMESTAMP_LTZ"],
     "BOOLEAN": ["BOOLEAN", "BOOL", "BIT"],
+    "ENUM": ["TEXT"],
 }
 
 
@@ -69,6 +68,33 @@ def load_excluded_cols(config_path=None):
     return set()
 
 
+def collect_excluded_cols(type_config=None, *configs):
+    """Merge ``excluded_cols`` from a type-mappings config and any number of
+    connection YAML configs (source / target).
+
+    Each config can be a file path (``str``) or an already-loaded ``dict``.
+    Returns a unified ``set`` of upper-cased column names.
+    """
+    merged: set[str] = set()
+
+    # Type-mappings config (the dedicated colcompare config file)
+    merged |= load_excluded_cols(type_config)
+
+    # Connection configs (source / target YAML dicts or paths)
+    for cfg in configs:
+        if cfg is None:
+            continue
+        if isinstance(cfg, str):
+            cfg = load_config(cfg)
+        raw = cfg.get("excluded_cols", [])
+        if raw:
+            merged |= {c.upper() for c in raw}
+
+    if merged:
+        logger.info(f"Total excluded columns (merged): {merged}")
+    return merged
+
+
 def generate_config_file(output_path="colcompare_config.yaml"):
     """Generate a default configuration file with type mappings."""
     config = {"type_mappings": DEFAULT_TYPE_MAPPINGS}
@@ -93,6 +119,11 @@ def generate_config_file(output_path="colcompare_config.yaml"):
             "excluded_cols:\n"
             "  # - CREATED_AT\n"
             "  # - UPDATED_AT\n"
+            "\n# Table name patterns to exclude (SQL-like % wildcards, case-insensitive)\n"
+            "# These are applied in the connection YAML, not here. Example:\n"
+            "# excluded_tables:\n"
+            "#   - %_FINAL\n"
+            "#   - TMP_%\n"
         )
 
     logger.info(f"Generated default config file at {output_path}")
@@ -311,52 +342,40 @@ def compare_columns(
 
 
 # ---------------------------------------------------------------------------
-# Excel report
+# HTML report helpers
 # ---------------------------------------------------------------------------
 
 
-def _format_worksheet(ws):
-    """Apply formatting to worksheet."""
-    header_fill = PatternFill(
-        start_color="366092", end_color="366092", fill_type="solid"
-    )
-    header_font = Font(color="FFFFFF", bold=True)
-    for cell in ws[1]:
-        cell.fill = header_fill
-        cell.font = header_font
-        cell.alignment = Alignment(horizontal="center")
-    for column in ws.columns:
-        column = list(column)
-        max_len = max((len(str(c.value or "")) for c in column), default=0)
-        ws.column_dimensions[get_column_letter(column[0].column)].width = min(
-            max_len + 2, 21.6
-        )
-
-
-def create_excel_report(
+def build_colcompare_tabs(
     comparison_results,
     source_df,
     target_df,
-    file_name,
     type_mappings=None,
     excluded_cols=None,
 ):
-    """Create formatted Excel report."""
-    wb = Workbook()
+    """Return a list of (tab_name, columns, data) tuples for the comparison.
+
+    This is decoupled from file I/O so that dbstats can merge tabs into a
+    single report when running in *both* mode.
+    """
+    tabs = []
 
     # --- Table Comparison ---
-    ws = wb.active
-    ws.title = "Table Comparison"
-    ws.append(["Category", "Table Name"])
+    table_rows = []
     for cat in ("common", "source_only", "target_only"):
         label = cat.replace("_", " ").title()
         for t in comparison_results["tables"][cat]:
-            ws.append([label, t])
-    _format_worksheet(ws)
+            table_rows.append({"Category": label, "Table Name": t})
+    tabs.append(
+        (
+            "Table Comparison",
+            HTMLReport.columns_from_names(["Category", "Table Name"]),
+            table_rows,
+        )
+    )
 
     # --- Column Comparison ---
-    ws2 = wb.create_sheet("Column Comparison")
-    ws2.append(["Table Name", "Column Name", "Status", "Source Type", "Target Type"])
+    col_rows = []
     for tbl in comparison_results["columns"]:
         tn = tbl["table_name"]
         src = dict(
@@ -383,23 +402,71 @@ def create_excel_report(
                 status = "Matching"
             else:
                 status = "Different Types"
-            ws2.append([tn, col, status, st, tt])
-    _format_worksheet(ws2)
+            col_rows.append(
+                {
+                    "Table Name": tn,
+                    "Column Name": col,
+                    "Status": status,
+                    "Source Type": st,
+                    "Target Type": tt,
+                }
+            )
+    tabs.append(
+        (
+            "Column Comparison",
+            HTMLReport.columns_from_names(
+                ["Table Name", "Column Name", "Status", "Source Type", "Target Type"]
+            ),
+            col_rows,
+        )
+    )
 
     # --- Datatype Mismatches ---
-    ws3 = wb.create_sheet("Datatype Mismatches")
-    ws3.append(["Table Name", "Column Name", "Source Type", "Target Type"])
+    mismatch_rows = []
     for tbl in comparison_results["columns"]:
         for m in tbl["datatype_mismatches"]:
-            ws3.append(
-                [tbl["table_name"], m["column"], m["source_type"], m["target_type"]]
+            mismatch_rows.append(
+                {
+                    "Table Name": tbl["table_name"],
+                    "Column Name": m["column"],
+                    "Source Type": m["source_type"],
+                    "Target Type": m["target_type"],
+                }
             )
-    _format_worksheet(ws3)
+    tabs.append(
+        (
+            "Datatype Mismatches",
+            HTMLReport.columns_from_names(
+                ["Table Name", "Column Name", "Source Type", "Target Type"]
+            ),
+            mismatch_rows,
+        )
+    )
 
-    os.makedirs("results", exist_ok=True)
-    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    return tabs
+
+
+def create_html_report(
+    comparison_results,
+    source_df,
+    target_df,
+    file_name,
+    type_mappings=None,
+    excluded_cols=None,
+):
+    """Create an interactive HTML report with Tabulator tables."""
+    tabs = build_colcompare_tabs(
+        comparison_results, source_df, target_df, type_mappings, excluded_cols
+    )
+
     safe_name = file_name.split("/")[-1] if "/" in file_name else file_name
-    wb.save(f"results/{safe_name}_{ts}.xlsx")
+    report = HTMLReport(f"Column Comparison — {safe_name}")
+    for tab_name, columns, data in tabs:
+        report.add_tab(tab_name, columns=columns, data=data)
+
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    output_path = f"results/{safe_name}_{ts}.html"
+    return report.save(output_path)
 
 
 # ---------------------------------------------------------------------------
@@ -410,7 +477,7 @@ def create_excel_report(
 def _run_comparison(
     source_df, target_df, report_name, type_mappings=None, excluded_cols=None
 ):
-    """Run table/column comparison and generate Excel report."""
+    """Run table/column comparison and generate HTML report."""
     table_comparison = compare_tables(source_df, target_df)
     column_comparisons = []
     for tbl in table_comparison["common"]:
@@ -418,35 +485,94 @@ def _run_comparison(
         column_comparisons.append({"table_name": tbl, **cc})
 
     results = {"tables": table_comparison, "columns": column_comparisons}
-    create_excel_report(
+    output_path = create_html_report(
         results, source_df, target_df, report_name, type_mappings, excluded_cols
     )
+    results["output_path"] = output_path
     return results
 
 
 def colcompare_from_db(
-    source_config_path, target_config_path, type_mappings=None, excluded_cols=None
+    source_config_path=None,
+    target_config_path=None,
+    type_mappings=None,
+    excluded_cols=None,
+    *,
+    report=None,
+    source_config=None,
+    target_config=None,
+    source_tables=None,
+    target_tables=None,
+    tables_file=None,
+    source_connector=None,
+    target_connector=None,
 ):
-    """Compare column schemas by fetching metadata directly from databases."""
-    with Timer("Database column comparison"):
-        source_config = load_config(source_config_path)
-        target_config = load_config(target_config_path)
+    """Compare column schemas by fetching metadata directly from databases.
 
-        tables_file = source_config.get("tables_file") or target_config.get(
-            "tables_file"
-        )
-        max_workers = source_config.get("max_workers", 4)
-        df, source_tables, target_tables = _read_table_lists(
-            tables_file, source_config, target_config
-        )
+    Parameters
+    ----------
+    source_config_path / target_config_path : str | None
+        Paths to YAML config files.  Ignored when *source_config* /
+        *target_config* are supplied directly.
+    report : HTMLReport | None
+        If provided, colcompare tabs are added to this existing report
+        instead of creating a standalone file.  Returns ``None`` in that
+        case (the caller is responsible for saving the report).
+    source_config / target_config : dict | None
+        Pre-loaded config dicts.  When provided the corresponding
+        ``*_config_path`` is not read, avoiding redundant I/O.
+    source_tables / target_tables : list[str] | None
+        Pre-discovered table lists.  When provided the table-discovery
+        step is skipped entirely, avoiding redundant database connections.
+    tables_file : str | None
+        Override for the tables CSV path.  Only used when table lists are
+        not supplied directly.
+    source_connector / target_connector : DBConnector | None
+        Already-connected database connectors.  When provided the
+        metadata fetch reuses these connections instead of opening new
+        ones.  The caller owns the connection lifecycle.
+    """
+    with Timer("Database column comparison"):
+        if source_config is None:
+            source_config = load_config(source_config_path)
+        if target_config is None:
+            target_config = load_config(target_config_path)
+
+        # Merge excluded_cols from source/target connection configs
+        # so users don't need a separate type-config file just for this.
+        cfg_excluded = collect_excluded_cols(None, source_config, target_config)
+        if cfg_excluded:
+            if excluded_cols is None:
+                excluded_cols = cfg_excluded
+            else:
+                excluded_cols = excluded_cols | cfg_excluded
+
+        # Discover tables only when the caller hasn't provided them
+        if source_tables is None:
+            if tables_file is None:
+                tables_file = source_config.get("tables_file") or target_config.get(
+                    "tables_file"
+                )
+            _df, source_tables, target_tables = _read_table_lists(
+                tables_file, source_config, target_config
+            )
+        else:
+            if tables_file is None:
+                tables_file = source_config.get("tables_file") or target_config.get(
+                    "tables_file"
+                )
 
         if target_tables is None:
             target_tables = source_tables
 
         # Fetch all column metadata per schema in a single query each,
         # then filter to only the tables we care about.
-        source_df = fetch_all_metadata_as_df(source_config, source_tables)
-        target_df = fetch_all_metadata_as_df(target_config, target_tables)
+        source_df = fetch_all_metadata_as_df(
+            source_config, source_tables, connector=source_connector
+        )
+        target_df = fetch_all_metadata_as_df(
+            target_config, target_tables, connector=target_connector
+        )
 
         if tables_file:
             report_name = Path(tables_file).stem
@@ -455,8 +581,41 @@ def colcompare_from_db(
 
             schema_label = get_schema_label(target_config)
             report_name = f"{schema_label}_colcompare_report"
-        _run_comparison(source_df, target_df, report_name, type_mappings, excluded_cols)
+
+        # Build comparison results
+        table_comparison = compare_tables(source_df, target_df)
+        column_comparisons = []
+        for tbl in table_comparison["common"]:
+            cc = compare_columns(
+                source_df, target_df, tbl, type_mappings, excluded_cols
+            )
+            column_comparisons.append({"table_name": tbl, **cc})
+        comp_results = {"tables": table_comparison, "columns": column_comparisons}
+
+        # If an external report was provided, append tabs to it
+        # Skip "Table Comparison" tab — the row-counts tab already covers that.
+        if report is not None:
+            tabs = build_colcompare_tabs(
+                comp_results, source_df, target_df, type_mappings, excluded_cols
+            )
+            for tab_name, columns, data in tabs:
+                if tab_name == "Table Comparison":
+                    continue
+                report.add_tab(tab_name, columns=columns, data=data)
+            logger.info("Database column comparison complete (tabs added to report)")
+            return None
+
+        # Standalone mode — write our own HTML file
+        output_path = create_html_report(
+            comp_results,
+            source_df,
+            target_df,
+            report_name,
+            type_mappings,
+            excluded_cols,
+        )
         logger.info("Database column comparison complete")
+        return output_path
 
 
 def colcompare(args=None):
@@ -516,7 +675,7 @@ To generate a default configuration file:
             generate_config_file(args.output)
             return
 
-        # Build excluded_cols set: CLI flag takes priority, then config file
+        # Build excluded_cols set: CLI flag merges with config file
         config_path = getattr(args, "config", None)
         if args.excluded_cols is not None:
             excluded_cols = {c.upper() for c in args.excluded_cols}
@@ -525,6 +684,11 @@ To generate a default configuration file:
 
         if args.source_config and args.target_config:
             tm = load_type_mappings(config_path)
+            excluded_cols = collect_excluded_cols(
+                config_path,
+                load_config(args.source_config),
+                load_config(args.target_config),
+            )
             colcompare_from_db(
                 args.source_config, args.target_config, tm, excluded_cols
             )
@@ -537,11 +701,10 @@ To generate a default configuration file:
 
     config_path = getattr(args, "config", None)
     type_mappings = load_type_mappings(config_path)
-    if not hasattr(args, "_excluded_cols_resolved"):
-        if getattr(args, "excluded_cols", None) is not None:
-            excluded_cols = {c.upper() for c in args.excluded_cols}
-        else:
-            excluded_cols = load_excluded_cols(config_path)
+    if getattr(args, "excluded_cols", None) is not None:
+        excluded_cols = {c.upper() for c in args.excluded_cols}
+    else:
+        excluded_cols = load_excluded_cols(config_path)
 
     with Timer("Column comparison"):
         source_df, target_df = read_files(args.source, args.target)

--- a/dbqt/tools/dbstats.py
+++ b/dbqt/tools/dbstats.py
@@ -1,17 +1,19 @@
 """Database statistics tool — row counts with optional column comparison."""
 
-import polars as pl
 import logging
+import os
 import threading
+
+import polars as pl
 
 from dbqt.tools.utils import (
     load_config,
     ConnectionPool,
     setup_logging,
     Timer,
+    HTMLReport,
     _read_table_lists,
-    get_metadata_for_table,
-    metadata_to_df,
+    get_schema_label,
 )
 
 logger = logging.getLogger(__name__)
@@ -65,15 +67,45 @@ def get_table_stats(
     config_path: str = None,
     source_config_path: str = None,
     target_config_path: str = None,
+    *,
+    report: HTMLReport = None,
+    source_config: dict = None,
+    target_config: dict = None,
+    table_lists: tuple = None,
 ):
-    """Collect row counts for tables listed in a CSV file."""
+    """Collect row counts for tables listed in a CSV file.
+
+    Parameters
+    ----------
+    report : HTMLReport | None
+        If provided, the row-count tab is added to this existing report
+        instead of creating a standalone file.  The caller is responsible
+        for saving the report.  Returns ``None`` in that case.
+    source_config / target_config : dict | None
+        Pre-loaded config dicts.  When provided the corresponding config
+        paths are not read, avoiding redundant file I/O.
+    table_lists : tuple | None
+        Pre-computed ``(df, source_tables, target_tables)`` from
+        ``_read_table_lists``.  When provided the table-discovery step is
+        skipped entirely, avoiding redundant database connections.
+    """
     with Timer("Database statistics collection"):
-        source_config, target_config, tables_file, max_workers = _load_configs(
-            config_path, source_config_path, target_config_path
-        )
-        df, source_tables, target_tables = _read_table_lists(
-            tables_file, source_config, target_config
-        )
+        if source_config is None or target_config is None:
+            source_config, target_config, tables_file, max_workers = _load_configs(
+                config_path, source_config_path, target_config_path
+            )
+        else:
+            tables_file = source_config.get("tables_file") or target_config.get(
+                "tables_file"
+            )
+            max_workers = source_config.get("max_workers", 4)
+
+        if table_lists is not None:
+            df, source_tables, target_tables = table_lists
+        else:
+            df, source_tables, target_tables = _read_table_lists(
+                tables_file, source_config, target_config
+            )
 
         if target_tables is not None:
             # source/target mode
@@ -201,16 +233,25 @@ def get_table_stats(
         if "_discovery_status" in df.columns:
             df = df.drop("_discovery_status")
 
+        # If an external report was provided, add the tab and return
+        if report is not None:
+            report.add_polars_tab("Row Counts", df)
+            logger.info("Row counts added to report")
+            return None
+
+        # Standalone mode — write our own HTML file
+        os.makedirs("results", exist_ok=True)
         if tables_file:
-            output_file = tables_file
+            base = os.path.splitext(os.path.basename(tables_file))[0]
         else:
-            from dbqt.tools.utils import get_schema_label
+            base = get_schema_label(target_config)
+        output_file = os.path.join("results", f"{base}_dbstats.html")
 
-            schema_label = get_schema_label(target_config)
-            output_file = f"{schema_label}_row_count.csv"
-
-        df.write_csv(output_file)
-        logger.info(f"Updated row counts in {output_file}")
+        standalone = HTMLReport(f"Database Statistics — {base}")
+        standalone.add_polars_tab("Row Counts", df)
+        standalone.save(output_file)
+        logger.info(f"Report saved to {output_file}")
+        return output_file
 
 
 # ---------------------------------------------------------------------------
@@ -224,7 +265,7 @@ def main(args=None):
         generate_config_file,
         colcompare_from_db,
         load_type_mappings,
-        load_excluded_cols,
+        collect_excluded_cols,
     )
 
     parser = argparse.ArgumentParser(
@@ -282,32 +323,91 @@ Examples:
 
     mode = args.mode
 
-    if mode in ("rowcount", "both"):
-        if args.source_config and args.target_config:
+    # Determine config sources
+    has_dual = args.source_config and args.target_config
+    has_single = args.config
+    if not has_dual and not has_single:
+        parser.error(
+            "Either --config or both --source-config and --target-config required"
+        )
+
+    if mode == "both":
+        # Build a single combined HTML report.
+        # Load configs and discover tables ONCE so that both row-count
+        # and column-comparison steps reuse them without reconnecting.
+        from datetime import datetime
+
+        if has_dual:
+            source_config = load_config(args.source_config)
+            target_config = load_config(args.target_config)
+        else:
+            source_config = target_config = load_config(args.config)
+
+        tables_file = source_config.get("tables_file") or target_config.get(
+            "tables_file"
+        )
+        if tables_file:
+            base = os.path.splitext(os.path.basename(tables_file))[0]
+        else:
+            base = get_schema_label(target_config)
+
+        # Discover tables once
+        table_lists = _read_table_lists(tables_file, source_config, target_config)
+        _df, source_tables, target_tables = table_lists
+
+        report = HTMLReport(f"Database Statistics — {base}")
+
+        # Row counts tab — pass pre-loaded configs and table lists
+        get_table_stats(
+            report=report,
+            source_config=source_config,
+            target_config=target_config,
+            table_lists=table_lists,
+        )
+
+        # Column comparison tabs — pass pre-loaded configs and table lists.
+        # Connectors are created inside colcompare_from_db (metadata fetch
+        # needs fresh connections after the row-count pool has shut down).
+        type_mappings = load_type_mappings(args.type_config)
+        excluded_cols = collect_excluded_cols(
+            args.type_config, source_config, target_config
+        )
+        colcompare_from_db(
+            type_mappings=type_mappings,
+            excluded_cols=excluded_cols,
+            report=report,
+            source_config=source_config,
+            target_config=target_config,
+            source_tables=source_tables,
+            target_tables=target_tables,
+            tables_file=tables_file,
+        )
+
+        # Save combined report
+        os.makedirs("results", exist_ok=True)
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        output_path = os.path.join("results", f"{base}_dbstats_{ts}.html")
+        report.save(output_path)
+
+    elif mode == "rowcount":
+        if has_dual:
             get_table_stats(
                 source_config_path=args.source_config,
                 target_config_path=args.target_config,
             )
-        elif args.config:
+        else:
             get_table_stats(config_path=args.config)
-        else:
-            parser.error(
-                "Either --config or both --source-config and --target-config required"
-            )
 
-    if mode in ("colcompare", "both"):
+    elif mode == "colcompare":
         type_mappings = load_type_mappings(args.type_config)
-        excluded_cols = load_excluded_cols(args.type_config)
-        if args.source_config and args.target_config:
-            colcompare_from_db(
-                args.source_config, args.target_config, type_mappings, excluded_cols
-            )
-        elif args.config:
-            colcompare_from_db(args.config, args.config, type_mappings, excluded_cols)
-        else:
-            parser.error(
-                "Either --config or both --source-config and --target-config required"
-            )
+        src_cfg_path = args.source_config or args.config
+        tgt_cfg_path = args.target_config or args.config
+        excluded_cols = collect_excluded_cols(
+            args.type_config,
+            load_config(src_cfg_path),
+            load_config(tgt_cfg_path),
+        )
+        colcompare_from_db(src_cfg_path, tgt_cfg_path, type_mappings, excluded_cols)
 
 
 if __name__ == "__main__":

--- a/dbqt/tools/utils.py
+++ b/dbqt/tools/utils.py
@@ -1,6 +1,7 @@
 """Shared utilities for dbqt tools."""
 
 import csv
+import json
 import yaml
 import logging
 import threading
@@ -182,6 +183,33 @@ def get_schema_label(config):
     return "default"
 
 
+def filter_excluded_tables(tables, excluded_patterns):
+    """Filter out tables matching any of the exclusion patterns.
+
+    Patterns use SQL-like wildcards: ``%`` matches any sequence of
+    characters.  Matching is case-insensitive.
+
+    Example patterns: ``%_FINAL``, ``TMP_%``, ``%_BAK_%``
+    """
+    if not excluded_patterns:
+        return tables
+
+    import re as _re
+
+    compiled = []
+    for pat in excluded_patterns:
+        regex = _re.escape(pat.upper()).replace(r"\%", ".*")
+        compiled.append(_re.compile(f"^{regex}$", _re.IGNORECASE))
+
+    filtered = [t for t in tables if not any(r.match(t) for r in compiled)]
+    removed = len(tables) - len(filtered)
+    if removed:
+        logger.info(
+            f"Excluded {removed} table(s) matching patterns: {excluded_patterns}"
+        )
+    return filtered
+
+
 def discover_tables_from_db(config):
     """Connect to a database and list all tables in the configured schema.
 
@@ -202,16 +230,32 @@ def _read_table_lists(tables_file, source_config=None, target_config=None):
     If *tables_file* is ``None``, tables are auto-discovered from the database
     schema defined in the YAML config(s).
 
+    Tables matching ``excluded_tables`` patterns in the YAML config(s) are
+    removed automatically.
+
     Returns target_tables=None when operating in single-config mode.
     """
     import polars as pl
 
+    # Collect exclusion patterns from config(s)
+    _exc_patterns = set()
+    for cfg in (source_config, target_config):
+        if cfg:
+            for pat in cfg.get("excluded_tables", []):
+                _exc_patterns.add(pat)
+    exc_patterns = sorted(_exc_patterns) if _exc_patterns else []
+
     if tables_file is not None:
         df = pl.read_csv(tables_file)
         if "source_table" in df.columns and "target_table" in df.columns:
-            return df, df["source_table"].to_list(), df["target_table"].to_list()
+            src = filter_excluded_tables(df["source_table"].to_list(), exc_patterns)
+            tgt = filter_excluded_tables(df["target_table"].to_list(), exc_patterns)
+            df = df.filter(pl.col("source_table").is_in(src))
+            return df, src, tgt
         elif "table_name" in df.columns:
-            return df, df["table_name"].to_list(), None
+            tables = filter_excluded_tables(df["table_name"].to_list(), exc_patterns)
+            df = df.filter(pl.col("table_name").is_in(tables))
+            return df, tables, None
         else:
             raise ValueError(
                 "CSV must contain 'table_name' or 'source_table'/'target_table' columns."
@@ -221,30 +265,46 @@ def _read_table_lists(tables_file, source_config=None, target_config=None):
     logger.info("No tables_file provided — discovering tables from database schema")
 
     if source_config and target_config and source_config is not target_config:
-        source_tables_set = set(discover_tables_from_db(source_config))
-        target_tables_set = set(discover_tables_from_db(target_config))
-        common = sorted(source_tables_set & target_tables_set)
-        source_only = sorted(source_tables_set - target_tables_set)
-        target_only = sorted(target_tables_set - source_tables_set)
+        source_tables_raw = filter_excluded_tables(
+            discover_tables_from_db(source_config), exc_patterns
+        )
+        target_tables_raw = filter_excluded_tables(
+            discover_tables_from_db(target_config), exc_patterns
+        )
+
+        # Build case-insensitive lookup maps: upper -> original
+        source_map = {t.upper(): t for t in source_tables_raw}
+        target_map = {t.upper(): t for t in target_tables_raw}
+
+        source_upper = set(source_map.keys())
+        target_upper = set(target_map.keys())
+
+        common_upper = sorted(source_upper & target_upper)
+        source_only_upper = sorted(source_upper - target_upper)
+        target_only_upper = sorted(target_upper - source_upper)
 
         rows = []
-        for t in common:
-            rows.append(
-                {"source_table": t, "target_table": t, "_discovery_status": "common"}
-            )
-        for t in source_only:
+        for u in common_upper:
             rows.append(
                 {
-                    "source_table": t,
-                    "target_table": t,
+                    "source_table": source_map[u],
+                    "target_table": target_map[u],
+                    "_discovery_status": "common",
+                }
+            )
+        for u in source_only_upper:
+            rows.append(
+                {
+                    "source_table": source_map[u],
+                    "target_table": source_map[u],
                     "_discovery_status": "source_only",
                 }
             )
-        for t in target_only:
+        for u in target_only_upper:
             rows.append(
                 {
-                    "source_table": t,
-                    "target_table": t,
+                    "source_table": target_map[u],
+                    "target_table": target_map[u],
                     "_discovery_status": "target_only",
                 }
             )
@@ -256,7 +316,9 @@ def _read_table_lists(tables_file, source_config=None, target_config=None):
             df["target_table"].to_list(),
         )
     elif source_config:
-        tables = discover_tables_from_db(source_config)
+        tables = filter_excluded_tables(
+            discover_tables_from_db(source_config), exc_patterns
+        )
         df = pl.DataFrame({"table_name": tables})
         return df, tables, None
     else:
@@ -326,22 +388,32 @@ def metadata_to_df(results, table_names):
     return pl.DataFrame(rows)
 
 
-def fetch_all_metadata_as_df(config, table_names=None):
+def fetch_all_metadata_as_df(config, table_names=None, connector=None):
     """Fetch column metadata for an entire schema in ONE query, return a Polars DataFrame.
 
     If *table_names* is provided the result is filtered to only those tables.
     This is much faster than ``fetch_metadata_parallel`` when many tables are
     involved because it issues a single ``SELECT … FROM information_schema.columns``
     (or equivalent) instead of one query per table.
+
+    Parameters
+    ----------
+    connector : DBConnector | None
+        An already-connected database connector.  When provided the caller
+        owns the connection lifecycle — this function will neither connect
+        nor disconnect it.
     """
     import polars as pl
 
-    connector = create_connector(config["connection"])
-    connector.connect()
+    owns_connection = connector is None
+    if owns_connection:
+        connector = create_connector(config["connection"])
+        connector.connect()
     try:
         raw = connector.fetch_schema_metadata()
     finally:
-        connector.disconnect()
+        if owns_connection:
+            connector.disconnect()
 
     # raw rows: (table_name, column_name, data_type, dt_prec, num_prec, num_scale)
     if not raw:
@@ -374,6 +446,217 @@ def fetch_all_metadata_as_df(config, table_names=None):
         df = df.filter(pl.col("SCH_TABLE").is_in(upper_names))
 
     return df
+
+
+# ---------------------------------------------------------------------------
+# HTML report builder (Tabulator-based)
+# ---------------------------------------------------------------------------
+
+_TABULATOR_CSS = (
+    "https://unpkg.com/tabulator-tables@6.3.1/dist/css/tabulator_midnight.min.css"
+)
+_TABULATOR_JS = "https://unpkg.com/tabulator-tables@6.3.1/dist/js/tabulator.min.js"
+_XLSX_JS = "https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js"
+
+
+class HTMLReport:
+    """Build a self-contained HTML file with tabbed Tabulator tables.
+
+    Usage::
+
+        report = HTMLReport("My Report")
+        report.add_tab("Row Counts", columns=[...], data=[...])
+        report.add_tab("Columns", columns=[...], data=[...])
+        report.save("results/report.html")
+    """
+
+    def __init__(self, title: str = "Report"):
+        self.title = title
+        self.tabs: list[dict] = []
+
+    # -- helpers to build Tabulator column definitions ----------------------
+
+    @staticmethod
+    def columns_from_names(names: list[str]) -> list[dict]:
+        """Create simple Tabulator column definitions from a list of names."""
+        return [
+            {"title": n, "field": n, "headerFilter": "input", "sorter": "string"}
+            for n in names
+        ]
+
+    @staticmethod
+    def columns_from_polars(df) -> list[dict]:
+        """Infer Tabulator column definitions from a Polars DataFrame."""
+        import polars as pl
+
+        cols = []
+        for name in df.columns:
+            dtype = df[name].dtype
+            if dtype in (
+                pl.Int8,
+                pl.Int16,
+                pl.Int32,
+                pl.Int64,
+                pl.UInt8,
+                pl.UInt16,
+                pl.UInt32,
+                pl.UInt64,
+                pl.Float32,
+                pl.Float64,
+            ):
+                sorter = "number"
+                hf = "number"
+                formatter = "plaintext"
+            else:
+                sorter = "string"
+                hf = "input"
+                formatter = "plaintext"
+            cols.append(
+                {
+                    "title": name,
+                    "field": name,
+                    "headerFilter": hf,
+                    "sorter": sorter,
+                    "formatter": formatter,
+                }
+            )
+        return cols
+
+    # -- adding tabs --------------------------------------------------------
+
+    def add_tab(self, name: str, *, columns: list[dict], data: list[dict]):
+        """Append a tab to the report.
+
+        *columns* – list of Tabulator column definition dicts.
+        *data*    – list of row dicts (JSON-serialisable).
+        """
+        self.tabs.append({"name": name, "columns": columns, "data": data})
+
+    def add_polars_tab(self, name: str, df):
+        """Convenience: add a tab directly from a Polars DataFrame."""
+        columns = self.columns_from_polars(df)
+        data = df.to_dicts()
+        # Ensure all values are JSON-serialisable (None is fine, but NaN is not)
+        for row in data:
+            for k, v in row.items():
+                if isinstance(v, float) and (v != v):  # NaN check
+                    row[k] = None
+        self.add_tab(name, columns=columns, data=data)
+
+    # -- rendering ----------------------------------------------------------
+
+    def _render(self) -> str:
+        tab_buttons = []
+        tab_divs = []
+        tab_scripts = []
+
+        for i, tab in enumerate(self.tabs):
+            tab_id = f"tab_{i}"
+            active = "active" if i == 0 else ""
+            display = "block" if i == 0 else "none"
+
+            tab_buttons.append(
+                f'<button class="tab-btn {active}" onclick="switchTab(event, \'{tab_id}\')">'
+                f'{tab["name"]}</button>'
+            )
+            tab_divs.append(
+                f'<div id="{tab_id}" class="tab-content" style="display:{display}">'
+                f'  <div id="{tab_id}_table"></div>'
+                f"</div>"
+            )
+            tab_scripts.append(
+                f'new Tabulator("#{tab_id}_table", {{\n'
+                f'  data: {json.dumps(tab["data"])},\n'
+                f'  columns: {json.dumps(tab["columns"])},\n'
+                f'  layout: "fitDataTable",\n'
+                f'  height: "calc(100vh - 120px)",\n'
+                f"  pagination: false,\n"
+                f"  movableColumns: true,\n"
+                f"  clipboard: true,\n"
+                f"  downloadConfig: {{ columnHeaders: true }},\n"
+                f"}});"
+            )
+
+        buttons_html = "\n".join(tab_buttons)
+        divs_html = "\n".join(tab_divs)
+        scripts_js = "\n".join(tab_scripts)
+
+        return f"""\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>{self.title}</title>
+<link rel="stylesheet" href="{_TABULATOR_CSS}">
+<script src="{_TABULATOR_JS}"></script>
+<script src="{_XLSX_JS}"></script>
+<style>
+  body {{ font-family: Arial, sans-serif; margin: 0; padding: 10px; background: #1a1a2e; color: #eee; }}
+  h1 {{ margin: 0 0 10px 0; font-size: 1.3em; }}
+  .tab-bar {{ display: flex; gap: 4px; margin-bottom: 8px; flex-wrap: wrap; align-items: center; }}
+  .tab-btn {{
+    padding: 6px 16px; border: none; cursor: pointer; border-radius: 4px 4px 0 0;
+    background: #16213e; color: #aaa; font-size: 0.9em;
+  }}
+  .tab-btn.active {{ background: #0f3460; color: #fff; }}
+  .tab-btn:hover {{ background: #0f3460; color: #fff; }}
+  .export-btn {{
+    margin-left: auto; padding: 6px 14px; border: 1px solid #555; border-radius: 4px;
+    background: #16213e; color: #ccc; cursor: pointer; font-size: 0.85em;
+  }}
+  .export-btn:hover {{ background: #0f3460; color: #fff; }}
+  .tab-content {{ display: none; }}
+</style>
+</head>
+<body>
+<h1>{self.title}</h1>
+<div class="tab-bar">
+  {buttons_html}
+  <button class="export-btn" onclick="exportXLSX()">⬇ Export XLSX</button>
+</div>
+{divs_html}
+<script>
+var tabulators = {{}};
+function switchTab(evt, tabId) {{
+  document.querySelectorAll('.tab-content').forEach(d => d.style.display = 'none');
+  document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+  document.getElementById(tabId).style.display = 'block';
+  evt.currentTarget.classList.add('active');
+}}
+function exportXLSX() {{
+  /* Build a multi-sheet XLSX using SheetJS from all Tabulator instances */
+  var wb = XLSX.utils.book_new();
+  var tabs = {json.dumps([t["name"] for t in self.tabs])};
+  for (var i = 0; i < tabs.length; i++) {{
+    var tableId = "tab_" + i + "_table";
+    var el = document.getElementById(tableId);
+    if (!el) continue;
+    var table = el.querySelector('.tabulator-table');
+    if (!table) continue;
+    var ws = XLSX.utils.table_to_sheet(el.querySelector('.tabulator-tableholder'));
+    /* Fallback: use JSON data */
+    if (!ws || !ws['!ref']) {{
+      var data = tabulators["tab_" + i] ? tabulators["tab_" + i].getData() : [];
+      ws = XLSX.utils.json_to_sheet(data);
+    }}
+    XLSX.utils.book_append_sheet(wb, ws, tabs[i].substring(0, 31));
+  }}
+  XLSX.writeFile(wb, "{self.title}.xlsx");
+}}
+{scripts_js}
+</script>
+</body>
+</html>"""
+
+    def save(self, path: str) -> str:
+        """Write the HTML report to *path* and return the path."""
+        import os
+
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(self._render())
+        logger.info(f"Report saved to {path}")
+        return path
 
 
 class Timer:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dbqt"
-version = "0.2.2"
+version = "0.3.0"
 description = "DataBase Quality Tool"
 authors = [
     { name = "NamiLink" }

--- a/tests/tools/test_dbstats.py
+++ b/tests/tools/test_dbstats.py
@@ -1,7 +1,8 @@
-import unittest
-from unittest.mock import MagicMock, patch, call
-import polars as pl
 import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+import polars as pl
 
 from dbqt.tools import dbstats
 
@@ -16,7 +17,6 @@ class TestDbStats(unittest.TestCase):
 
         self.assertEqual(result, ("test_table", (1000, None)))
         mock_connector.count_rows.assert_called_once_with("test_table")
-        # Verify thread name was set
         self.assertEqual(threading.current_thread().name, "Table-test_table")
 
     def test_get_row_count_for_table_error(self):
@@ -29,321 +29,395 @@ class TestDbStats(unittest.TestCase):
         self.assertEqual(result, ("test_table", (None, "Database error")))
         mock_connector.count_rows.assert_called_once_with("test_table")
 
+    @patch("dbqt.tools.dbstats.HTMLReport")
     @patch("dbqt.tools.dbstats.Timer")
     @patch("dbqt.tools.dbstats.ConnectionPool")
+    @patch("dbqt.tools.dbstats._read_table_lists")
     @patch("dbqt.tools.dbstats.load_config")
-    @patch("polars.read_csv")
     def test_get_table_stats_source_target_tables(
-        self, mock_read_csv, mock_load_config, mock_pool, mock_timer
+        self, mock_load_config, mock_read_tables, mock_pool, mock_timer, mock_report_cls
     ):
         """Test get_table_stats with source_table and target_table columns."""
-        # Setup mocks
-        mock_config = {"tables_file": "tables.csv", "max_workers": 4}
-        mock_load_config.return_value = mock_config
+        source_config = {
+            "connection": {"type": "mysql"},
+            "tables_file": "tables.csv",
+            "max_workers": 4,
+        }
+        target_config = {
+            "connection": {"type": "mysql"},
+            "tables_file": "tables.csv",
+            "max_workers": 4,
+        }
+        mock_load_config.side_effect = [source_config, target_config]
 
-        # Create mock dataframe with source and target tables
-        mock_df = MagicMock()
-        mock_df.columns = ["source_table", "target_table"]
-        mock_df.__getitem__.side_effect = lambda key: {
-            "source_table": MagicMock(to_list=lambda: ["table1", "table2"]),
-            "target_table": MagicMock(to_list=lambda: ["table3", "table4"]),
-        }[key]
+        df = pl.DataFrame(
+            {
+                "source_table": ["table1", "table2"],
+                "target_table": ["table1", "table2"],
+            }
+        )
+        mock_read_tables.return_value = (
+            df,
+            ["table1", "table2"],
+            ["table1", "table2"],
+        )
 
-        # Create a new mock for the dataframe after with_columns
-        mock_df_after_columns = MagicMock()
-        mock_df_after_columns.columns = [
-            "source_table",
-            "target_table",
-            "source_row_count",
-            "source_notes",
-            "target_row_count",
-            "target_notes",
-        ]
-        mock_df_after_columns.with_columns.return_value = mock_df_after_columns
-        mock_df_after_columns.select.return_value = mock_df_after_columns
-        mock_df.with_columns.return_value = mock_df_after_columns
-
-        mock_read_csv.return_value = mock_df
-
-        # Mock connection pool
         mock_pool_instance = mock_pool.return_value.__enter__.return_value
         mock_pool_instance.execute_parallel.return_value = {
             "table1": (100, None),
             "table2": (200, None),
-            "table3": (150, None),
-            "table4": (250, None),
         }
 
-        # Mock timer
-        mock_timer_instance = mock_timer.return_value.__enter__.return_value
+        mock_report = mock_report_cls.return_value
+        mock_report.save.return_value = "results/tables_dbstats.html"
 
-        dbstats.get_table_stats("config.yaml")
-
-        # Verify calls
-        mock_load_config.assert_called_once_with("config.yaml")
-        mock_read_csv.assert_called_once_with("tables.csv")
-        mock_pool.assert_called_once_with(mock_config, 4)
-        mock_pool_instance.execute_parallel.assert_called_once_with(
-            dbstats.get_row_count_for_table, ["table1", "table2", "table3", "table4"]
+        result = dbstats.get_table_stats(
+            source_config_path="source.yaml",
+            target_config_path="target.yaml",
         )
 
-        # Verify dataframe operations
-        self.assertTrue(mock_df.with_columns.called)
-        self.assertTrue(mock_df_after_columns.select.called)
-        mock_df_after_columns.write_csv.assert_called_once_with("tables.csv")
+        self.assertEqual(result, "results/tables_dbstats.html")
+        self.assertEqual(mock_pool.call_count, 2)
+        mock_report.add_polars_tab.assert_called_once()
+        mock_report.save.assert_called_once()
 
+    @patch("dbqt.tools.dbstats.HTMLReport")
     @patch("dbqt.tools.dbstats.Timer")
     @patch("dbqt.tools.dbstats.ConnectionPool")
+    @patch("dbqt.tools.dbstats._read_table_lists")
     @patch("dbqt.tools.dbstats.load_config")
-    @patch("polars.read_csv")
     def test_get_table_stats_single_table_column(
-        self, mock_read_csv, mock_load_config, mock_pool, mock_timer
+        self, mock_load_config, mock_read_tables, mock_pool, mock_timer, mock_report_cls
     ):
         """Test get_table_stats with table_name column."""
-        # Setup mocks
-        mock_config = {"tables_file": "tables.csv", "max_workers": 2}
-        mock_load_config.return_value = mock_config
+        config = {
+            "connection": {"type": "mysql"},
+            "tables_file": "tables.csv",
+            "max_workers": 2,
+        }
+        mock_load_config.return_value = config
 
-        # Create mock dataframe with table_name column
-        mock_df = MagicMock()
-        mock_df.columns = ["table_name"]
-        mock_df.__getitem__.side_effect = lambda key: {
-            "table_name": MagicMock(to_list=lambda: ["table1", "table2"])
-        }[key]
-        mock_df.with_columns.return_value = mock_df
-        mock_read_csv.return_value = mock_df
+        df = pl.DataFrame({"table_name": ["table1", "table2"]})
+        mock_read_tables.return_value = (df, ["table1", "table2"], None)
 
-        # Mock connection pool
         mock_pool_instance = mock_pool.return_value.__enter__.return_value
         mock_pool_instance.execute_parallel.return_value = {
             "table1": (100, None),
             "table2": (200, "Error message"),
         }
 
-        dbstats.get_table_stats("config.yaml")
+        mock_report = mock_report_cls.return_value
+        mock_report.save.return_value = "results/tables_dbstats.html"
 
-        # Verify calls
-        mock_load_config.assert_called_once_with("config.yaml")
-        mock_read_csv.assert_called_once_with("tables.csv")
-        mock_pool.assert_called_once_with(mock_config, 2)
-        mock_pool_instance.execute_parallel.assert_called_once_with(
-            dbstats.get_row_count_for_table, ["table1", "table2"]
-        )
+        result = dbstats.get_table_stats(config_path="config.yaml")
 
-        # Verify dataframe operations
-        mock_df.with_columns.assert_called_once()
-        mock_df.write_csv.assert_called_once_with("tables.csv")
+        self.assertEqual(result, "results/tables_dbstats.html")
+        mock_pool.assert_called_once_with(config, 2)
+        mock_report.add_polars_tab.assert_called_once()
 
     @patch("dbqt.tools.dbstats.Timer")
+    @patch("dbqt.tools.dbstats._read_table_lists")
     @patch("dbqt.tools.dbstats.load_config")
-    @patch("polars.read_csv")
-    @patch("dbqt.tools.dbstats.logger")
     def test_get_table_stats_invalid_columns(
-        self, mock_logger, mock_read_csv, mock_load_config, mock_timer
+        self, mock_load_config, mock_read_tables, mock_timer
     ):
         """Test get_table_stats with invalid column structure."""
-        # Setup mocks
-        mock_config = {"tables_file": "tables.csv", "max_workers": 4}
-        mock_load_config.return_value = mock_config
-
-        # Create mock dataframe with invalid columns
-        mock_df = MagicMock()
-        mock_df.columns = ["invalid_column"]
-        mock_read_csv.return_value = mock_df
-
-        dbstats.get_table_stats("config.yaml")
-
-        # Verify error was logged
-        mock_logger.error.assert_called_once_with(
-            "CSV file must contain either 'table_name' column or 'source_table' and 'target_table' columns."
+        config = {
+            "connection": {"type": "mysql"},
+            "tables_file": "tables.csv",
+            "max_workers": 4,
+        }
+        mock_load_config.return_value = config
+        mock_read_tables.side_effect = ValueError(
+            "CSV must contain 'table_name' or 'source_table'/'target_table' columns."
         )
 
+        with self.assertRaises(ValueError):
+            dbstats.get_table_stats(config_path="config.yaml")
+
+    @patch("dbqt.tools.dbstats.HTMLReport")
     @patch("dbqt.tools.dbstats.Timer")
     @patch("dbqt.tools.dbstats.ConnectionPool")
+    @patch("dbqt.tools.dbstats._read_table_lists")
     @patch("dbqt.tools.dbstats.load_config")
-    @patch("polars.read_csv")
     def test_get_table_stats_default_max_workers(
-        self, mock_read_csv, mock_load_config, mock_pool, mock_timer
+        self, mock_load_config, mock_read_tables, mock_pool, mock_timer, mock_report_cls
     ):
         """Test get_table_stats uses default max_workers when not specified."""
-        # Setup mocks - no max_workers in config
-        mock_config = {"tables_file": "tables.csv"}
-        mock_load_config.return_value = mock_config
+        config = {"connection": {"type": "mysql"}, "tables_file": "tables.csv"}
+        mock_load_config.return_value = config
 
-        # Create mock dataframe
-        mock_df = MagicMock()
-        mock_df.columns = ["table_name"]
-        mock_df.__getitem__.side_effect = lambda key: {
-            "table_name": MagicMock(to_list=lambda: ["table1"])
-        }[key]
-        mock_df.with_columns.return_value = mock_df
-        mock_read_csv.return_value = mock_df
+        df = pl.DataFrame({"table_name": ["table1"]})
+        mock_read_tables.return_value = (df, ["table1"], None)
 
-        # Mock connection pool
         mock_pool_instance = mock_pool.return_value.__enter__.return_value
         mock_pool_instance.execute_parallel.return_value = {"table1": (100, None)}
 
-        dbstats.get_table_stats("config.yaml")
+        mock_report = mock_report_cls.return_value
+        mock_report.save.return_value = "results/tables_dbstats.html"
 
-        # Verify default max_workers of 4 was used
-        mock_pool.assert_called_once_with(mock_config, 4)
+        dbstats.get_table_stats(config_path="config.yaml")
+
+        mock_pool.assert_called_once_with(config, 1)
 
     @patch("dbqt.tools.dbstats.setup_logging")
     @patch("dbqt.tools.dbstats.get_table_stats")
     def test_main_with_args(self, mock_get_table_stats, mock_setup_logging):
         """Test main function with command line arguments."""
-        args = ["--config", "test_config.yaml", "--verbose"]
+        args = ["rowcount", "--config", "test_config.yaml", "--verbose"]
 
         dbstats.main(args)
 
         mock_setup_logging.assert_called_once_with(True)
-        mock_get_table_stats.assert_called_once_with("test_config.yaml")
+        mock_get_table_stats.assert_called_once_with(config_path="test_config.yaml")
 
     @patch("dbqt.tools.dbstats.setup_logging")
     @patch("dbqt.tools.dbstats.get_table_stats")
     def test_main_without_verbose(self, mock_get_table_stats, mock_setup_logging):
         """Test main function without verbose flag."""
-        args = ["--config", "test_config.yaml"]
+        args = ["rowcount", "--config", "test_config.yaml"]
 
         dbstats.main(args)
 
         mock_setup_logging.assert_called_once_with(False)
-        mock_get_table_stats.assert_called_once_with("test_config.yaml")
+        mock_get_table_stats.assert_called_once_with(config_path="test_config.yaml")
 
     @patch("dbqt.tools.dbstats.setup_logging")
     @patch("dbqt.tools.dbstats.get_table_stats")
-    @patch("argparse.ArgumentParser.parse_args")
-    def test_main_no_args(
-        self, mock_parse_args, mock_get_table_stats, mock_setup_logging
-    ):
-        """Test main function when called without arguments (uses argparse)."""
-        mock_args = MagicMock()
-        mock_args.config = "default_config.yaml"
-        mock_args.verbose = False
-        mock_parse_args.return_value = mock_args
+    def test_main_no_args(self, mock_get_table_stats, mock_setup_logging):
+        """Test main function when called without arguments raises SystemExit."""
+        with self.assertRaises(SystemExit):
+            dbstats.main([])
 
-        dbstats.main(None)
-
-        mock_parse_args.assert_called_once()
-        mock_setup_logging.assert_called_once_with(False)
-        mock_get_table_stats.assert_called_once_with("default_config.yaml")
-
-    @patch("polars.Series")
+    @patch("dbqt.tools.dbstats.HTMLReport")
     @patch("dbqt.tools.dbstats.Timer")
     @patch("dbqt.tools.dbstats.ConnectionPool")
+    @patch("dbqt.tools.dbstats._read_table_lists")
     @patch("dbqt.tools.dbstats.load_config")
-    @patch("polars.read_csv")
     def test_get_table_stats_column_operations_source_target(
-        self, mock_read_csv, mock_load_config, mock_pool, mock_timer, mock_series
+        self, mock_load_config, mock_read_tables, mock_pool, mock_timer, mock_report_cls
     ):
         """Test detailed column operations for source/target table scenario."""
-        # Setup mocks
-        mock_config = {"tables_file": "tables.csv", "max_workers": 4}
-        mock_load_config.return_value = mock_config
-
-        # Create mock dataframe
-        mock_df = MagicMock()
-        mock_df.columns = ["source_table", "target_table", "other_col"]
-
-        # Mock the column access
-        source_col_mock = MagicMock()
-        source_col_mock.to_list.return_value = ["src1", "src2"]
-        target_col_mock = MagicMock()
-        target_col_mock.to_list.return_value = ["tgt1", "tgt2"]
-
-        mock_df.__getitem__.side_effect = lambda key: {
-            "source_table": source_col_mock,
-            "target_table": target_col_mock,
-        }[key]
-
-        # Mock dataframe operations - create separate mock for after with_columns
-        mock_df_with_columns = MagicMock()
-        mock_df_with_columns.columns = [
-            "source_table",
-            "target_table",
-            "other_col",
-            "source_row_count",
-            "source_notes",
-            "target_row_count",
-            "target_notes",
-        ]
-        mock_df_with_columns.with_columns.return_value = mock_df_with_columns
-        mock_df_with_columns.select.return_value = mock_df_with_columns
-        mock_df.with_columns.return_value = mock_df_with_columns
-
-        mock_read_csv.return_value = mock_df
-
-        # Mock connection pool
-        mock_pool_instance = mock_pool.return_value.__enter__.return_value
-        mock_pool_instance.execute_parallel.return_value = {
-            "src1": (100, None),
-            "src2": (200, "Error"),
-            "tgt1": (150, None),
-            "tgt2": (250, None),
+        source_config = {
+            "connection": {"type": "mysql"},
+            "tables_file": "tables.csv",
+            "max_workers": 4,
         }
+        target_config = {
+            "connection": {"type": "mysql"},
+            "tables_file": "tables.csv",
+            "max_workers": 4,
+        }
+        mock_load_config.side_effect = [source_config, target_config]
 
-        # Mock polars Series creation
-        mock_series.side_effect = lambda name, data: MagicMock(name=f"Series_{name}")
+        df = pl.DataFrame(
+            {
+                "source_table": ["src1", "src2"],
+                "target_table": ["tgt1", "tgt2"],
+            }
+        )
+        mock_read_tables.return_value = (
+            df,
+            ["src1", "src2"],
+            ["tgt1", "tgt2"],
+        )
 
-        dbstats.get_table_stats("config.yaml")
-
-        # Verify Series were created with correct data
-        expected_calls = [
-            call("source_row_count", [100, 200]),
-            call("source_notes", [None, "Error"]),
-            call("target_row_count", [150, 250]),
-            call("target_notes", [None, None]),
+        mock_pool_instance = mock_pool.return_value.__enter__.return_value
+        mock_pool_instance.execute_parallel.side_effect = [
+            {"src1": (100, None), "src2": (200, "Error")},
+            {"tgt1": (150, None), "tgt2": (250, None)},
         ]
-        mock_series.assert_has_calls(expected_calls, any_order=True)
 
-    @patch("polars.Series")
+        mock_report = mock_report_cls.return_value
+        mock_report.save.return_value = "results/tables_dbstats.html"
+
+        result = dbstats.get_table_stats(
+            source_config_path="source.yaml",
+            target_config_path="target.yaml",
+        )
+
+        self.assertEqual(result, "results/tables_dbstats.html")
+        # Verify the report received a Polars tab
+        mock_report.add_polars_tab.assert_called_once()
+        tab_name, tab_df = mock_report.add_polars_tab.call_args[0]
+        self.assertEqual(tab_name, "Row Counts")
+        self.assertIn("source_row_count", tab_df.columns)
+        self.assertIn("target_row_count", tab_df.columns)
+
+    @patch("dbqt.tools.dbstats.HTMLReport")
     @patch("dbqt.tools.dbstats.Timer")
     @patch("dbqt.tools.dbstats.ConnectionPool")
+    @patch("dbqt.tools.dbstats._read_table_lists")
     @patch("dbqt.tools.dbstats.load_config")
-    @patch("polars.read_csv")
     def test_get_table_stats_column_operations_single_table(
-        self, mock_read_csv, mock_load_config, mock_pool, mock_timer, mock_series
+        self, mock_load_config, mock_read_tables, mock_pool, mock_timer, mock_report_cls
     ):
         """Test detailed column operations for single table scenario."""
-        # Setup mocks
-        mock_config = {"tables_file": "tables.csv", "max_workers": 4}
-        mock_load_config.return_value = mock_config
+        config = {
+            "connection": {"type": "mysql"},
+            "tables_file": "tables.csv",
+            "max_workers": 4,
+        }
+        mock_load_config.return_value = config
 
-        # Create mock dataframe
-        mock_df = MagicMock()
-        mock_df.columns = ["table_name"]
+        df = pl.DataFrame({"table_name": ["table1", "table2"]})
+        mock_read_tables.return_value = (df, ["table1", "table2"], None)
 
-        # Mock the column access
-        table_col_mock = MagicMock()
-        table_col_mock.to_list.return_value = ["table1", "table2"]
-        mock_df.__getitem__.side_effect = lambda key: {"table_name": table_col_mock}[
-            key
-        ]
-
-        # Mock dataframe operations
-        mock_df_with_columns = MagicMock()
-        mock_df.with_columns.return_value = mock_df_with_columns
-
-        mock_read_csv.return_value = mock_df
-
-        # Mock connection pool
         mock_pool_instance = mock_pool.return_value.__enter__.return_value
         mock_pool_instance.execute_parallel.return_value = {
             "table1": (100, None),
             "table2": (200, "Error message"),
         }
 
-        # Mock polars Series creation
-        mock_series.side_effect = lambda name, data: MagicMock(name=f"Series_{name}")
+        mock_report = mock_report_cls.return_value
+        mock_report.save.return_value = "results/tables_dbstats.html"
 
-        dbstats.get_table_stats("config.yaml")
+        result = dbstats.get_table_stats(config_path="config.yaml")
 
-        # Verify Series were created with correct data
-        expected_calls = [
-            call("row_count", [100, 200]),
-            call("notes", [None, "Error message"]),
-        ]
-        mock_series.assert_has_calls(expected_calls, any_order=True)
+        self.assertEqual(result, "results/tables_dbstats.html")
+        mock_report.add_polars_tab.assert_called_once()
+        tab_name, tab_df = mock_report.add_polars_tab.call_args[0]
+        self.assertEqual(tab_name, "Row Counts")
+        self.assertIn("row_count", tab_df.columns)
+        self.assertIn("notes", tab_df.columns)
+        # Verify actual data
+        self.assertEqual(tab_df["row_count"].to_list(), [100, 200])
+        self.assertEqual(tab_df["notes"].to_list(), [None, "Error message"])
+
+    @patch("dbqt.tools.dbstats.HTMLReport")
+    @patch("dbqt.tools.colcompare.colcompare_from_db")
+    @patch("dbqt.tools.dbstats._read_table_lists")
+    @patch("dbqt.tools.dbstats.load_config")
+    @patch("dbqt.tools.dbstats.setup_logging")
+    def test_main_both_mode_reuses_configs_and_tables(
+        self,
+        mock_setup_logging,
+        mock_load_config,
+        mock_read_tables,
+        mock_colcompare,
+        mock_report_cls,
+    ):
+        """Test that 'both' mode loads configs and discovers tables only once."""
+        source_config = {
+            "connection": {"type": "mysql"},
+            "tables_file": "tables.csv",
+            "max_workers": 4,
+        }
+        target_config = {
+            "connection": {"type": "mysql"},
+            "tables_file": "tables.csv",
+            "max_workers": 4,
+        }
+        mock_load_config.side_effect = [source_config, target_config]
+
+        df = pl.DataFrame(
+            {
+                "source_table": ["table1", "table2"],
+                "target_table": ["table1", "table2"],
+            }
+        )
+        table_lists = (df, ["table1", "table2"], ["table1", "table2"])
+        mock_read_tables.return_value = table_lists
+
+        mock_report = mock_report_cls.return_value
+        mock_report.save.return_value = "results/tables_dbstats.html"
+
+        with (
+            patch("dbqt.tools.dbstats.ConnectionPool") as mock_pool,
+            patch("dbqt.tools.dbstats.Timer"),
+        ):
+            mock_pool_instance = mock_pool.return_value.__enter__.return_value
+            mock_pool_instance.execute_parallel.return_value = {
+                "table1": (100, None),
+                "table2": (200, None),
+            }
+
+            dbstats.main(
+                [
+                    "both",
+                    "--source-config",
+                    "source.yaml",
+                    "--target-config",
+                    "target.yaml",
+                ]
+            )
+
+        # load_config called exactly twice (once per config file)
+        self.assertEqual(mock_load_config.call_count, 2)
+
+        # _read_table_lists called exactly once (shared between rowcount and colcompare)
+        mock_read_tables.assert_called_once()
+
+        # colcompare_from_db received pre-loaded configs and table lists
+        mock_colcompare.assert_called_once()
+        call_kwargs = mock_colcompare.call_args[1]
+        self.assertIs(call_kwargs["source_config"], source_config)
+        self.assertIs(call_kwargs["target_config"], target_config)
+        self.assertEqual(call_kwargs["source_tables"], ["table1", "table2"])
+        self.assertEqual(call_kwargs["target_tables"], ["table1", "table2"])
+
+    @patch("dbqt.tools.dbstats.HTMLReport")
+    @patch("dbqt.tools.colcompare.colcompare_from_db")
+    @patch("dbqt.tools.dbstats._read_table_lists")
+    @patch("dbqt.tools.dbstats.load_config")
+    @patch("dbqt.tools.dbstats.setup_logging")
+    def test_main_both_mode_merges_excluded_cols_from_configs(
+        self,
+        mock_setup_logging,
+        mock_load_config,
+        mock_read_tables,
+        mock_colcompare,
+        mock_report_cls,
+    ):
+        """Test that 'both' mode merges excluded_cols from source and target configs."""
+        source_config = {
+            "connection": {"type": "mysql"},
+            "tables_file": "tables.csv",
+            "max_workers": 4,
+            "excluded_cols": ["CREATED_AT"],
+        }
+        target_config = {
+            "connection": {"type": "mysql"},
+            "tables_file": "tables.csv",
+            "max_workers": 4,
+            "excluded_cols": ["UPDATED_AT"],
+        }
+        mock_load_config.side_effect = [source_config, target_config]
+
+        df = pl.DataFrame(
+            {
+                "source_table": ["table1"],
+                "target_table": ["table1"],
+            }
+        )
+        table_lists = (df, ["table1"], ["table1"])
+        mock_read_tables.return_value = table_lists
+
+        mock_report = mock_report_cls.return_value
+        mock_report.save.return_value = "results/tables_dbstats.html"
+
+        with (
+            patch("dbqt.tools.dbstats.ConnectionPool") as mock_pool,
+            patch("dbqt.tools.dbstats.Timer"),
+        ):
+            mock_pool_instance = mock_pool.return_value.__enter__.return_value
+            mock_pool_instance.execute_parallel.return_value = {
+                "table1": (100, None),
+            }
+
+            dbstats.main(
+                [
+                    "both",
+                    "--source-config",
+                    "source.yaml",
+                    "--target-config",
+                    "target.yaml",
+                ]
+            )
+
+        mock_colcompare.assert_called_once()
+        call_kwargs = mock_colcompare.call_args[1]
+        self.assertEqual(call_kwargs["excluded_cols"], {"CREATED_AT", "UPDATED_AT"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Replaces Excel (openpyxl) and CSV output with interactive, self-contained HTML reports powered by [Tabulator](https://tabulator.info/). Adds a combined `both` mode to `dbstats` and introduces table exclusion patterns.

## Breaking Changes
- Output format changed from `.xlsx`/`.csv` to `.html` — downstream consumers expecting Excel or CSV files will need to update.
- `openpyxl` is no longer required.

## Changes

### HTML Report Output
- **New `HTMLReport` class** in `dbqt/tools/utils.py` — builds self-contained HTML files with tabbed Tabulator tables featuring column sorting, header filtering, movable columns, and a one-click XLSX export button via SheetJS.
- **`colcompare`** now generates `.html` reports instead of `.xlsx` (removes `openpyxl` dependency).
- **`dbstats`** now generates `.html` reports instead of writing back to the input CSV.

### Combined `both` Mode
- `dbstats both` runs row counts and column comparison in a single command, producing one unified HTML report.
- Configs are loaded once and table lists are discovered once, then shared between both steps to avoid redundant I/O and database connections.

### Table Exclusion Patterns
- New `excluded_tables` YAML config option accepts SQL-like `%` wildcard patterns (case-insensitive).
- `filter_excluded_tables()` utility applies patterns to both CSV-provided and auto-discovered table lists.
- Works across all tools that use `_read_table_lists()`.

### Excluded Columns Merging
- New `collect_excluded_cols()` merges `excluded_cols` from the type-config file and source/target connection YAML configs into a single set.
- `colcompare_from_db` automatically picks up `excluded_cols` from connection configs.

### Other Improvements
- Case-insensitive table matching during auto-discovery (cross-database comparisons).
- `fetch_all_metadata_as_df()` and `colcompare_from_db()` accept pre-connected `connector` objects to avoid opening redundant connections.
- Expanded `DEFAULT_TYPE_MAPPINGS`: added `ENUM`, `TIMESTAMP_NTZ`, `TIMESTAMP_LTZ`, `DATETIME` groups.
- `build_colcompare_tabs()` factored out for reuse by `dbstats both` mode.
- Version bumped to `0.3.0`.

### Tests
- Rewrote `test_dbstats.py` to use real Polars DataFrames instead of deeply nested MagicMock chains.
- Added tests for `both` mode config/table reuse and excluded_cols merging.
- All existing test scenarios preserved with updated assertions.